### PR TITLE
rename as_bits -> to_bits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,8 +158,15 @@ impl f16 {
 
     /// Converts an `f16` into the underlying bit representation.
     #[inline]
-    pub fn as_bits(self) -> u16 {
+    pub fn to_bits(self) -> u16 {
         self.0
+    }
+
+    /// Converts an `f16` into the underlying bit representation.
+    #[deprecated(since = "1.2.0", note = "renamed to to_bits")]
+    #[inline]
+    pub fn as_bits(self) -> u16 {
+        self.to_bits()
     }
 
     /// Converts an `f16` value in a `f32` value.


### PR DESCRIPTION
I'm not sure about the `deprecated(since = "version")`, I guess it would be 1.2.0 so that's what I put in.

Fixes #12.