### PR TITLE
Convert between arrays of u16 bits and f16 numbers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -828,6 +828,7 @@ pub mod slice {
 
     /// Reinterpret a slice of u16 bits as a slice of f16 numbers.
     // the transmuted slice has the same life time as the original
+    #[inline]
     pub fn from_bits<'s>(bits: &'s [u16]) -> &'s [f16] {
         let pointer = bits.as_ptr() as *const f16;
         let length = bits.len();
@@ -836,6 +837,7 @@ pub mod slice {
 
     /// Reinterpret a slice of f16 numbers as a slice of u16 bits.
     // the transmuted slice has the same life time as the original
+    #[inline]
     pub fn to_bits<'s>(bits: &'s [f16]) -> &'s [u16] {
         let pointer = bits.as_ptr() as *const u16;
         let length = bits.len();
@@ -1198,11 +1200,11 @@ mod test {
         // Checks only pointer and len,
         // but we know these are the same
         // because we just transmuted them, so
-        assert_eq!(a, b, "array conversion: pointer and length equality");
+        assert_eq!(a, b);
 
         // We need to perform manual content equality checks
         for (a, b) in a.iter().zip(b.iter()) {
-            assert_eq!(a, b, "array conversion: element equality");
+            assert_eq!(a, b);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1196,7 +1196,7 @@ mod test {
         assert_slice_contents_eq(&to_bits, &bits_cloned);
     }
 
-    fn assert_slice_contents_eq<T: PartialEq + Debug>(a: &[T], b: &[T]){
+    fn assert_slice_contents_eq<T: PartialEq + core::fmt::Debug>(a: &[T], b: &[T]){
         // Checks only pointer and len,
         // but we know these are the same
         // because we just transmuted them, so

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,6 +816,87 @@ mod convert {
     }
 }
 
+/// Contains utility functions to convert between slices of u16 bits and f16 numbers.
+pub mod slice {
+    use super::f16;
+    use core::slice;
+
+    // `from_bits_mut` and `to_bits_mut` would result in
+    // multiple mutable slices (the original and the reinterpreted)
+    // pointing to the same block of data, which violates basic mutability rules.
+
+
+    /// Reinterpret a slice of u16 bits as a slice of f16 numbers.
+    // the transmuted slice has the same life time as the original
+    pub fn from_bits<'s>(bits: &'s [u16]) -> &'s [f16] {
+        let pointer = bits.as_ptr() as *const f16;
+        let length = bits.len();
+        unsafe { slice::from_raw_parts(pointer, length) }
+    }
+
+    /// Reinterpret a slice of f16 numbers as a slice of u16 bits.
+    // the transmuted slice has the same life time as the original
+    pub fn to_bits<'s>(bits: &'s [f16]) -> &'s [u16] {
+        let pointer = bits.as_ptr() as *const u16;
+        let length = bits.len();
+        unsafe { slice::from_raw_parts(pointer, length) }
+    }
+}
+
+/// Contains utility functions to convert between vectors of u16 bits and f16 vectors.
+#[cfg(feature = "std")]
+pub mod vec {
+    use super::f16;
+    use core::mem;
+
+    /// Converts a vector of u16 elements into a vector of f16 elements.
+    /// This function merely reinterprets the contents of the vector,
+    /// so it's basically a free operation.
+    #[inline]
+    pub fn from_bits(bits: Vec<u16>) -> Vec<f16> {
+        let mut bits = bits;
+
+        // An f16 array has same length and capacity as u16 array
+        let length = bits.len();
+        let capacity = bits.capacity();
+
+        // Actually reinterpret the contents of the Vec<u16> as f16,
+        // knowing that structs are represented as only their members in memory,
+        // which is the u16 part of `f16(u16)`
+        let pointer = bits.as_mut_ptr() as *mut f16;
+
+        // Prevent running a destructor on the old Vec<u16>, so the pointer won't be deleted
+        mem::forget(bits);
+
+        // Finally construct a new Vec<f16> from the raw pointer
+        unsafe { Vec::from_raw_parts(pointer, length, capacity) }
+    }
+
+    /// Converts a vector of f16 elements into a vector of u16 elements.
+    /// This function merely reinterprets the contents of the vector,
+    /// so it's basically a free operation.
+    #[inline]
+    pub fn to_bits(numbers: Vec<f16>) -> Vec<u16> {
+        let mut numbers = numbers;
+
+        // An f16 array has same length and capacity as u16 array
+        let length = numbers.len();
+        let capacity = numbers.capacity();
+
+        // Actually reinterpret the contents of the Vec<f16> as u16,
+        // knowing that structs are represented as only their members in memory,
+        // which is the u16 part of `f16(u16)`
+        let pointer = numbers.as_mut_ptr() as *mut u16;
+
+        // Prevent running a destructor on the old Vec<u16>, so the pointer won't be deleted
+        mem::forget(numbers);
+
+        // Finally construct a new Vec<f16> from the raw pointer
+        unsafe { Vec::from_raw_parts(pointer, length, capacity) }
+    }
+}
+
+
 #[cfg(test)]
 mod test {
     use core;
@@ -1079,5 +1160,49 @@ mod test {
         assert!(!(neg_one > one));
         assert!(one >= neg_one);
         assert!(!(neg_one >= one));
+    }
+
+    #[test]
+    fn test_slice_conversions(){
+        use consts::*;
+        let bits = &[E.to_bits(), PI.to_bits(), EPSILON.to_bits(), FRAC_1_SQRT_2.to_bits()];
+        let numbers = &[E, PI, EPSILON, FRAC_1_SQRT_2];
+
+        // Convert from bits to numbers
+        let from_bits = slice::from_bits(bits);
+        assert_slice_contents_eq(from_bits, numbers);
+
+        // Convert from numbers back to bits
+        let to_bits = slice::to_bits(from_bits);
+        assert_slice_contents_eq(to_bits, bits);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_vec_conversions(){
+        use consts::*;
+        let numbers = vec![E, PI, EPSILON, FRAC_1_SQRT_2];
+        let bits = vec![E.to_bits(), PI.to_bits(), EPSILON.to_bits(), FRAC_1_SQRT_2.to_bits()];
+        let bits_cloned = bits.clone();
+
+        // Convert from bits to numbers
+        let from_bits = vec::from_bits(bits);
+        assert_slice_contents_eq(&from_bits, &numbers);
+
+        // Convert from numbers back to bits
+        let to_bits = vec::to_bits(from_bits);
+        assert_slice_contents_eq(&to_bits, &bits_cloned);
+    }
+
+    fn assert_slice_contents_eq<T: PartialEq + Debug>(a: &[T], b: &[T]){
+        // Checks only pointer and len,
+        // but we know these are the same
+        // because we just transmuted them, so
+        assert_eq!(a, b, "array conversion: pointer and length equality");
+
+        // We need to perform manual content equality checks
+        for (a, b) in a.iter().zip(b.iter()) {
+            assert_eq!(a, b, "array conversion: element equality");
+        }
     }
 }


### PR DESCRIPTION
This commit will add support for conversion between slices and vectors of u16 bits and f16 numbers. It should close #14.

Two modules are introduced, `slice` and `vec`. The `vec` module will only be included if the `std` feature is enabled, because vectors require `std`. Each module contains the functions `from_bits` and `to_bits`, like the `f16` type. The contents of the arrays are unsafely cast to the desired type, assuming that in Rust an array of `f16(u16)` will always be represented by an array of `u16` in memory. This is faster than using `into_iter().map(f16::from_bits).collect()`.

The commit also includes some simple tests, which were executed using Rust 1.15.0. More detailed tests should probably be added in the future. 