### PR TITLE
make docs.rs document vec module that requires std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ version = "1.0"
 optional = true
 default-features = false
 features = ["derive"]
+
+[package.metadata.docs.rs]
+features = ["std"]


### PR DESCRIPTION
Currently, the vec module is undocumented in docs.rs, because it requires the std feature. This PR makes docs.rs use the std feature when documenting the crate.