### PR TITLE
more consistent NaN conversions

### DIFF
--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -867,11 +867,11 @@ mod test {
     }
 
     #[test]
-    fn test_nan_conversion() {
-        let nan64 = f64::from_bits(0x7ff0_0000_0000_0001u64);
-        let neg_nan64 = f64::from_bits(0xfff0_0000_0000_0001u64);
-        let nan32 = f32::from_bits(0x7f80_0001u32);
-        let neg_nan32 = f32::from_bits(0xff80_0001u32);
+    fn test_nan_conversion_to_smaller() {
+        let nan64 = f64::from_bits(0x7FF0_0000_0000_0001u64);
+        let neg_nan64 = f64::from_bits(0xFFF0_0000_0000_0001u64);
+        let nan32 = f32::from_bits(0x7F80_0001u32);
+        let neg_nan32 = f32::from_bits(0xFF80_0001u32);
         let nan32_from_64 = nan64 as f32;
         let neg_nan32_from_64 = neg_nan64 as f32;
         let nan16_from_64 = bf16::from_f64(nan64);
@@ -879,40 +879,41 @@ mod test {
         let nan16_from_32 = bf16::from_f32(nan32);
         let neg_nan16_from_32 = bf16::from_f32(neg_nan32);
 
-        assert!(nan64.is_nan());
-        assert!(neg_nan64.is_nan());
-        assert!(nan32.is_nan());
-        assert!(neg_nan32.is_nan());
-        assert!(nan32_from_64.is_nan());
-        assert!(neg_nan32_from_64.is_nan());
-        assert!(nan16_from_64.is_nan());
-        assert!(neg_nan16_from_64.is_nan());
-        assert!(nan16_from_32.is_nan());
-        assert!(neg_nan16_from_32.is_nan());
+        assert!(nan64.is_nan() && nan64.is_sign_positive());
+        assert!(neg_nan64.is_nan() && neg_nan64.is_sign_negative());
+        assert!(nan32.is_nan() && nan32.is_sign_positive());
+        assert!(neg_nan32.is_nan() && neg_nan32.is_sign_negative());
+        assert!(nan32_from_64.is_nan() && nan32_from_64.is_sign_positive());
+        assert!(neg_nan32_from_64.is_nan() && neg_nan32_from_64.is_sign_negative());
+        assert!(nan16_from_64.is_nan() && nan16_from_64.is_sign_positive());
+        assert!(neg_nan16_from_64.is_nan() && neg_nan16_from_64.is_sign_negative());
+        assert!(nan16_from_32.is_nan() && nan16_from_32.is_sign_positive());
+        assert!(neg_nan16_from_32.is_nan() && neg_nan16_from_32.is_sign_negative());
+    }
 
-        let sign64 = 1u64 << 63;
-        let sign32 = 1u32 << 31;
-        let sign16 = 1u16 << 15;
-        let nan64_u = nan64.to_bits();
-        let neg_nan64_u = neg_nan64.to_bits();
-        let nan32_u = nan32.to_bits();
-        let neg_nan32_u = neg_nan32.to_bits();
-        let nan32_from_64_u = nan32_from_64.to_bits();
-        let neg_nan32_from_64_u = neg_nan32_from_64.to_bits();
-        let nan16_from_64_u = nan16_from_64.to_bits();
-        let neg_nan16_from_64_u = neg_nan16_from_64.to_bits();
-        let nan16_from_32_u = nan16_from_32.to_bits();
-        let neg_nan16_from_32_u = neg_nan16_from_32.to_bits();
-        assert_eq!(nan64_u & sign64, 0);
-        assert_eq!(neg_nan64_u & sign64, sign64);
-        assert_eq!(nan32_u & sign32, 0);
-        assert_eq!(neg_nan32_u & sign32, sign32);
-        assert_eq!(nan32_from_64_u & sign32, 0);
-        assert_eq!(neg_nan32_from_64_u & sign32, sign32);
-        assert_eq!(nan16_from_64_u & sign16, 0);
-        assert_eq!(neg_nan16_from_64_u & sign16, sign16);
-        assert_eq!(nan16_from_32_u & sign16, 0);
-        assert_eq!(neg_nan16_from_32_u & sign16, sign16);
+    #[test]
+    fn test_nan_conversion_to_larger() {
+        let nan16 = bf16::from_bits(0x7F81u16);
+        let neg_nan16 = bf16::from_bits(0xFF81u16);
+        let nan32 = f32::from_bits(0x7F80_0001u32);
+        let neg_nan32 = f32::from_bits(0xFF80_0001u32);
+        let nan32_from_16 = f32::from(nan16);
+        let neg_nan32_from_16 = f32::from(neg_nan16);
+        let nan64_from_16 = f64::from(nan16);
+        let neg_nan64_from_16 = f64::from(neg_nan16);
+        let nan64_from_32 = f64::from(nan32);
+        let neg_nan64_from_32 = f64::from(neg_nan32);
+
+        assert!(nan16.is_nan() && nan16.is_sign_positive());
+        assert!(neg_nan16.is_nan() && neg_nan16.is_sign_negative());
+        assert!(nan32.is_nan() && nan32.is_sign_positive());
+        assert!(neg_nan32.is_nan() && neg_nan32.is_sign_negative());
+        assert!(nan32_from_16.is_nan() && nan32_from_16.is_sign_positive());
+        assert!(neg_nan32_from_16.is_nan() && neg_nan32_from_16.is_sign_negative());
+        assert!(nan64_from_16.is_nan() && nan64_from_16.is_sign_positive());
+        assert!(neg_nan64_from_16.is_nan() && neg_nan64_from_16.is_sign_negative());
+        assert!(nan64_from_32.is_nan() && nan64_from_32.is_sign_positive());
+        assert!(neg_nan64_from_32.is_nan() && neg_nan64_from_32.is_sign_negative());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1105,11 +1105,11 @@ mod test {
     }
 
     #[test]
-    fn test_nan_conversion() {
-        let nan64 = f64::from_bits(0x7ff0_0000_0000_0001u64);
-        let neg_nan64 = f64::from_bits(0xfff0_0000_0000_0001u64);
-        let nan32 = f32::from_bits(0x7f80_0001u32);
-        let neg_nan32 = f32::from_bits(0xff80_0001u32);
+    fn test_nan_conversion_to_smaller() {
+        let nan64 = f64::from_bits(0x7FF0_0000_0000_0001u64);
+        let neg_nan64 = f64::from_bits(0xFFF0_0000_0000_0001u64);
+        let nan32 = f32::from_bits(0x7F80_0001u32);
+        let neg_nan32 = f32::from_bits(0xFF80_0001u32);
         let nan32_from_64 = nan64 as f32;
         let neg_nan32_from_64 = neg_nan64 as f32;
         let nan16_from_64 = f16::from_f64(nan64);
@@ -1117,40 +1117,41 @@ mod test {
         let nan16_from_32 = f16::from_f32(nan32);
         let neg_nan16_from_32 = f16::from_f32(neg_nan32);
 
-        assert!(nan64.is_nan());
-        assert!(neg_nan64.is_nan());
-        assert!(nan32.is_nan());
-        assert!(neg_nan32.is_nan());
-        assert!(nan32_from_64.is_nan());
-        assert!(neg_nan32_from_64.is_nan());
-        assert!(nan16_from_64.is_nan());
-        assert!(neg_nan16_from_64.is_nan());
-        assert!(nan16_from_32.is_nan());
-        assert!(neg_nan16_from_32.is_nan());
+        assert!(nan64.is_nan() && nan64.is_sign_positive());
+        assert!(neg_nan64.is_nan() && neg_nan64.is_sign_negative());
+        assert!(nan32.is_nan() && nan32.is_sign_positive());
+        assert!(neg_nan32.is_nan() && neg_nan32.is_sign_negative());
+        assert!(nan32_from_64.is_nan() && nan32_from_64.is_sign_positive());
+        assert!(neg_nan32_from_64.is_nan() && neg_nan32_from_64.is_sign_negative());
+        assert!(nan16_from_64.is_nan() && nan16_from_64.is_sign_positive());
+        assert!(neg_nan16_from_64.is_nan() && neg_nan16_from_64.is_sign_negative());
+        assert!(nan16_from_32.is_nan() && nan16_from_32.is_sign_positive());
+        assert!(neg_nan16_from_32.is_nan() && neg_nan16_from_32.is_sign_negative());
+    }
 
-        let sign64 = 1u64 << 63;
-        let sign32 = 1u32 << 31;
-        let sign16 = 1u16 << 15;
-        let nan64_u = nan64.to_bits();
-        let neg_nan64_u = neg_nan64.to_bits();
-        let nan32_u = nan32.to_bits();
-        let neg_nan32_u = neg_nan32.to_bits();
-        let nan32_from_64_u = nan32_from_64.to_bits();
-        let neg_nan32_from_64_u = neg_nan32_from_64.to_bits();
-        let nan16_from_64_u = nan16_from_64.to_bits();
-        let neg_nan16_from_64_u = neg_nan16_from_64.to_bits();
-        let nan16_from_32_u = nan16_from_32.to_bits();
-        let neg_nan16_from_32_u = neg_nan16_from_32.to_bits();
-        assert_eq!(nan64_u & sign64, 0);
-        assert_eq!(neg_nan64_u & sign64, sign64);
-        assert_eq!(nan32_u & sign32, 0);
-        assert_eq!(neg_nan32_u & sign32, sign32);
-        assert_eq!(nan32_from_64_u & sign32, 0);
-        assert_eq!(neg_nan32_from_64_u & sign32, sign32);
-        assert_eq!(nan16_from_64_u & sign16, 0);
-        assert_eq!(neg_nan16_from_64_u & sign16, sign16);
-        assert_eq!(nan16_from_32_u & sign16, 0);
-        assert_eq!(neg_nan16_from_32_u & sign16, sign16);
+    #[test]
+    fn test_nan_conversion_to_larger() {
+        let nan16 = f16::from_bits(0x7C01u16);
+        let neg_nan16 = f16::from_bits(0xFC01u16);
+        let nan32 = f32::from_bits(0x7F80_0001u32);
+        let neg_nan32 = f32::from_bits(0xFF80_0001u32);
+        let nan32_from_16 = f32::from(nan16);
+        let neg_nan32_from_16 = f32::from(neg_nan16);
+        let nan64_from_16 = f64::from(nan16);
+        let neg_nan64_from_16 = f64::from(neg_nan16);
+        let nan64_from_32 = f64::from(nan32);
+        let neg_nan64_from_32 = f64::from(neg_nan32);
+
+        assert!(nan16.is_nan() && nan16.is_sign_positive());
+        assert!(neg_nan16.is_nan() && neg_nan16.is_sign_negative());
+        assert!(nan32.is_nan() && nan32.is_sign_positive());
+        assert!(neg_nan32.is_nan() && neg_nan32.is_sign_negative());
+        assert!(nan32_from_16.is_nan() && nan32_from_16.is_sign_positive());
+        assert!(neg_nan32_from_16.is_nan() && neg_nan32_from_16.is_sign_negative());
+        assert!(nan64_from_16.is_nan() && nan64_from_16.is_sign_positive());
+        assert!(neg_nan64_from_16.is_nan() && neg_nan64_from_16.is_sign_negative());
+        assert!(nan64_from_32.is_nan() && nan64_from_32.is_sign_positive());
+        assert!(neg_nan64_from_32.is_nan() && neg_nan64_from_32.is_sign_negative());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,8 +606,6 @@ mod convert {
 
 #[cfg(not(feature = "use-intrinsics"))]
 mod convert {
-    use core;
-
     // In the below functions, round to nearest, with ties to even.
     // Let us call the most significant bit that will be shifted out the round_bit.
     //
@@ -763,8 +761,8 @@ mod convert {
             if half_man == 0 {
                 return f32::from_bits((half_sign << 16) | 0x7F80_0000u32);
             } else {
-                // NaN, only 1st mantissa bit is set
-                return core::f32::NAN;
+                // NaN, keep current mantissa but also set most significiant mantissa bit
+                return f32::from_bits((half_sign << 16) | 0x7FC0_0000u32 | (half_man << 13));
             }
         }
 
@@ -806,8 +804,10 @@ mod convert {
             if half_man == 0 {
                 return f64::from_bits((half_sign << 48) | 0x7FF0_0000_0000_0000u64);
             } else {
-                // NaN, only 1st mantissa bit is set
-                return core::f64::NAN;
+                // NaN, keep current mantissa but also set most significiant mantissa bit
+                return f64::from_bits(
+                    (half_sign << 48) | 0x7FF8_0000_0000_0000u64 | (half_man << 42),
+                );
             }
         }
 


### PR DESCRIPTION
This PR makes all NaN conversions behave like NaN conversions between `f32` and `f64`:
  * Retain sign.
  * Retain as many mantissa bits as possible.
  * Set most significant mantissa bit.

In NaN conversion tests, conversion between `f32` and `f64` are included to show that the crate's conversions are consistent with them.

Fixes #23.