### PR TITLE
Add `#[repr(transparent)]` to `f16`/`bf16` types

### DIFF
--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -26,6 +26,7 @@ pub(crate) mod convert;
 /// [`f16`]: struct.f16.html
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Default)]
+#[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct bf16(u16);
 

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -23,6 +23,7 @@ pub(crate) mod convert;
 /// [`binary16`]: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Default)]
+#[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct f16(u16);
 


### PR DESCRIPTION
Currently this crate wraps an `u16` using a tuple struct into a new type. This is fine, as long the memory representation of this new type is irrelevant (as it is in safe Rust code).

Unfortunately, there is at least one function, that reinterprets an `u16` into a `f16` or `bf16` using casting:
https://github.com/starkat99/half-rs/blob/5f01541c72030584f2160816b9b4c7ee45a4b657/src/vec.rs#L161-L178
At this point, the memory representation of the type is important. Rust does not guarantee, that the wrapping tuple-struct has the same representation as the wrapped type. This possibly leads to undefined behavior!

At this point the `#[repr(transparent)]` attribute is helpful: it serves exactly that purpose to guarantee the same memory layout according to the [nomicon](https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent). Using this attribute on the `f16` and `bf16` structs, the pointer casting remains valid and removes the UB.

All previous tests still pass. I have not added a new test case, as I don't know a way to test the presence of attributes or the correctness of the codegen.