### PR TITLE
Fix as_ptr() -> as_mut_ptr() finding from Miri.

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -568,7 +568,7 @@ impl HalfBitsSliceExt for [u16] {
     where
         H: crate::private::SealedHalf,
     {
-        let pointer = self.as_ptr() as *mut H;
+        let pointer = self.as_mut_ptr() as *mut H;
         let length = self.len();
         // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
         // and the size of elements are identical


### PR DESCRIPTION
I'm adding a dependency on half to a large project and wanted to give it a quick
check with miri. The miri stacked borrows checker had an issue with using a non
mutable pointer in the mutable reinterpret cast. Its not clear to me if this
was really indicative of a problem, but the version miri is happy with does look
better to me.

(note there were two other miri failures but they look like a problem
with miri itself - https://github.com/rust-lang/rust/issues/69532)