### PR TITLE
add to_le_bytes method for f16

### DIFF
--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -291,6 +291,13 @@ impl f16 {
         self.0
     }
 
+    /// Return the memory representation of the underlying bit representation as a byte array in
+    /// little-endian byte order.
+    #[inline]
+    pub const fn to_le_bytes(self) -> [u8; 2] {
+        self.0.to_le_bytes()
+    }
+
     /// Converts a [`f16`](struct.f16.html) into the underlying bit representation.
     #[deprecated(since = "1.2.0", note = "renamed to [`to_bits`](#method.to_bits)")]
     #[inline]


### PR DESCRIPTION
I found myself needing a `to_le_bytes` method on `f16`. This is because of the use case I am dealing with: a macro which ends up calling the `to_le_bytes` method on various numeric types that it receives. It doesn't feel nice to put in a separate case for `f16`, where you'd have the macro generate `my_val.0.to_le_bytes()`, instead of the usual `my_val.to_le_bytes()`. 

I'll probably use my fork of half-rs for now, but I wondered if such a method would also be nice to have in the main half-rs crate? (Having it in there would also mean that I could just use the main crate :D)

Note that currently, it does not compile because: 

```
error: `core::num::<impl u16>::to_le_bytes` is not yet stable as a const fn
```
So, I'd appreciate some insight into how you'd handle this!