### PR TITLE
Optional bytemuck support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,12 @@ use-intrinsics = []
 serialize = ["serde"] # Deprecated. Use serde directly.
 alloc = []
 
+[dependencies.bytemuck]
+version = "1.4.1"
+optional = true
+default-features = false
+features = ["derive"]
+
 [dependencies.serde]
 version = "1.0"
 optional = true

--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
+
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Error, Formatter, LowerExp, UpperExp},
@@ -28,6 +31,7 @@ pub(crate) mod convert;
 #[derive(Clone, Copy, Default)]
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
 pub struct bf16(u16);
 
 impl bf16 {

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
+
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Error, Formatter, LowerExp, UpperExp},
@@ -25,6 +28,7 @@ pub(crate) mod convert;
 #[derive(Clone, Copy, Default)]
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
 pub struct f16(u16);
 
 #[deprecated(


### PR DESCRIPTION
Adds optional bytemuck Zeroable + Pod implementations for f16 / bf16. This is particularly useful with FFI, and allows safe conversions to bytes and back. 