### PR TITLE
Optional num-traits implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,11 @@ optional = true
 default-features = false
 features = ["derive"]
 
+[dependencies.num-traits]
+version = "0.2.14"
+optional = true
+default-features = false
+
 [package.metadata.docs.rs]
 features = ["std", "serde"]
 

--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -642,6 +642,8 @@ mod impl_num_traits {
         fn from_u16(n: u16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
         fn from_i32(n: i32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
         fn from_u32(n: u32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_f32(n: f32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_f64(n: f64) -> Option<Self> { n.to_f64().map(|x| Self::from_f64(x)) }
     }
 }
 

--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "num-traits")]
-use num_traits::{Zero, One, ToPrimitive, FromPrimitive};
-
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Error, Formatter, LowerExp, UpperExp},
@@ -619,39 +616,33 @@ impl UpperExp for bf16 {
 }
 
 #[cfg(feature = "num-traits")]
-impl Zero for bf16 {
-    fn zero() -> Self { Self::default() }
-}
+mod impl_num_traits {
+    use super::bf16;
+    use num_traits::{ToPrimitive, FromPrimitive};
+    
+    impl ToPrimitive for bf16 {
+        fn to_i64(&self) -> Option<i64> { Self::to_f32(*self).to_i64() }
+        fn to_u64(&self) -> Option<u64> { Self::to_f32(*self).to_u64() }
+        fn to_i8(&self) -> Option<i8> { Self::to_f32(*self).to_i8() }
+        fn to_u8(&self) -> Option<u8> { Self::to_f32(*self).to_u8() }
+        fn to_i16(&self) -> Option<i16> { Self::to_f32(*self).to_i16() }
+        fn to_u16(&self) -> Option<u16> { Self::to_f32(*self).to_u16() }
+        fn to_i32(&self) -> Option<i32> { Self::to_f32(*self).to_i32() }
+        fn to_u32(&self) -> Option<u32> { Self::to_f32(*self).to_u32() }
+        fn to_f32(&self) -> Option<f32> { Some(Self::to_f32(*self)) }
+        fn to_f64(&self) -> Option<f64> { Some(Self::to_f64(*self)) }
+    }
 
-#[cfg(feature = "num-traits")]
-impl One for bf16 {
-    fn one() -> Self { Self::from_f32(1.) }
-}
-
-#[cfg(feature = "num-traits")]
-impl ToPrimitive for bf16 {
-    fn to_i64(&self) -> Option<i64> { self.to_f32().to_i64() }
-    fn to_u64(&self) -> Option<u64> { self.to_f32().to_i64() }
-    fn to_i8(&self) -> Option<i8> { self.to_f32().to_i8() }
-    fn to_u8(&self) -> Option<u8> { self.to_f32().to_u8() }
-    fn to_i16(&self) -> Option<i16> { self.to_f32().to_i16() }
-    fn to_u16(&self) -> Option<u16> { self.to_f32().to_u16() }
-    fn to_i32(&self) -> Option<i32> { self.to_f32().to_i32() }
-    fn to_u32(&self) -> Option<u32> { self.to_f32().to_u32() }
-    fn to_f32(&self) -> Option<f32> { Some(self.to_f32()) }
-    fn to_f64(&self) -> Option<f32> { Some(self.to_f64()) }
-}
-
-#[cfg(feature = "num-traits")]
-impl FromPrimitive for bf16 {
-    fn from_i64(n: i64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_u64(n: u64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_i8(n: i8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_u8(n: u8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_i16(n: i16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_u16(n: u16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_i32(n: i32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_u32(n: u32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    impl FromPrimitive for bf16 {
+        fn from_i64(n: i64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_u64(n: u64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_i8(n: i8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_u8(n: u8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_i16(n: i16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_u16(n: u16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_i32(n: i32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_u32(n: u32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    }
 }
 
 #[allow(

--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "num-traits")]
+use num_traits::{Zero, One, ToPrimitive, FromPrimitive};
+
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Error, Formatter, LowerExp, UpperExp},
@@ -613,6 +616,42 @@ impl UpperExp for bf16 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         write!(f, "{:E}", self.to_f32())
     }
+}
+
+#[cfg(feature = "num-traits")]
+impl Zero for bf16 {
+    fn zero() -> Self { Self::default() }
+}
+
+#[cfg(feature = "num-traits")]
+impl One for bf16 {
+    fn one() -> Self { Self::from_f32(1.) }
+}
+
+#[cfg(feature = "num-traits")]
+impl ToPrimitive for bf16 {
+    fn to_i64(&self) -> Option<i64> { self.to_f32().to_i64() }
+    fn to_u64(&self) -> Option<u64> { self.to_f32().to_i64() }
+    fn to_i8(&self) -> Option<i8> { self.to_f32().to_i8() }
+    fn to_u8(&self) -> Option<u8> { self.to_f32().to_u8() }
+    fn to_i16(&self) -> Option<i16> { self.to_f32().to_i16() }
+    fn to_u16(&self) -> Option<u16> { self.to_f32().to_u16() }
+    fn to_i32(&self) -> Option<i32> { self.to_f32().to_i32() }
+    fn to_u32(&self) -> Option<u32> { self.to_f32().to_u32() }
+    fn to_f32(&self) -> Option<f32> { Some(self.to_f32()) }
+    fn to_f64(&self) -> Option<f32> { Some(self.to_f64()) }
+}
+
+#[cfg(feature = "num-traits")]
+impl FromPrimitive for bf16 {
+    fn from_i64(n: i64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_u64(n: u64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_i8(n: i8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_u8(n: u8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_i16(n: i16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_u16(n: u16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_i32(n: i32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_u32(n: u32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
 }
 
 #[allow(

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "num-traits")]
+use num_traits::{Zero, One, ToPrimitive, FromPrimitive};
+
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Error, Formatter, LowerExp, UpperExp},
@@ -26,6 +29,42 @@ pub(crate) mod convert;
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct f16(u16);
+
+#[cfg(feature = "num-traits")]
+impl Zero for f16 {
+    fn zero() -> Self { Self::default() }
+}
+
+#[cfg(feature = "num-traits")]
+impl One for f16 {
+    fn one() -> Self { Self::from_f32(1.) }
+}
+
+#[cfg(feature = "num-traits")]
+impl ToPrimitive for bf16 {
+    fn to_i64(&self) -> Option<i64> { self.to_f32().to_i64() }
+    fn to_u64(&self) -> Option<u64> { self.to_f32().to_i64() }
+    fn to_i8(&self) -> Option<i8> { self.to_f32().to_i8() }
+    fn to_u8(&self) -> Option<u8> { self.to_f32().to_u8() }
+    fn to_i16(&self) -> Option<i16> { self.to_f32().to_i16() }
+    fn to_u16(&self) -> Option<u16> { self.to_f32().to_u16() }
+    fn to_i32(&self) -> Option<i32> { self.to_f32().to_i32() }
+    fn to_u32(&self) -> Option<u32> { self.to_f32().to_u32() }
+    fn to_f32(&self) -> Option<f32> { Some(self.to_f32()) }
+    fn to_f64(&self) -> Option<f32> { Some(self.to_f64()) }
+}
+
+#[cfg(feature = "num-traits")]
+impl FromPrimitive for f16 {
+    fn from_i64(n: i64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_u64(n: u64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_i8(n: i8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_u8(n: u8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_i16(n: i16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_u16(n: u16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_i32(n: i32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    fn from_u32(n: u32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+}
 
 #[deprecated(
     since = "1.4.0",

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -1,9 +1,6 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "num-traits")]
-use num_traits::{Zero, One, ToPrimitive, FromPrimitive};
-
 use core::{
     cmp::Ordering,
     fmt::{Debug, Display, Error, Formatter, LowerExp, UpperExp},
@@ -31,39 +28,33 @@ pub(crate) mod convert;
 pub struct f16(u16);
 
 #[cfg(feature = "num-traits")]
-impl Zero for f16 {
-    fn zero() -> Self { Self::default() }
-}
+mod impl_num_traits {
+    use super::f16;
+    use num_traits::{ToPrimitive, FromPrimitive};
+    
+    impl ToPrimitive for f16 {
+        fn to_i64(&self) -> Option<i64> { Self::to_f32(*self).to_i64() }
+        fn to_u64(&self) -> Option<u64> { Self::to_f32(*self).to_u64() }
+        fn to_i8(&self) -> Option<i8> { Self::to_f32(*self).to_i8() }
+        fn to_u8(&self) -> Option<u8> { Self::to_f32(*self).to_u8() }
+        fn to_i16(&self) -> Option<i16> { Self::to_f32(*self).to_i16() }
+        fn to_u16(&self) -> Option<u16> { Self::to_f32(*self).to_u16() }
+        fn to_i32(&self) -> Option<i32> { Self::to_f32(*self).to_i32() }
+        fn to_u32(&self) -> Option<u32> { Self::to_f32(*self).to_u32() }
+        fn to_f32(&self) -> Option<f32> { Some(Self::to_f32(*self)) }
+        fn to_f64(&self) -> Option<f64> { Some(Self::to_f64(*self)) }
+    }
 
-#[cfg(feature = "num-traits")]
-impl One for f16 {
-    fn one() -> Self { Self::from_f32(1.) }
-}
-
-#[cfg(feature = "num-traits")]
-impl ToPrimitive for bf16 {
-    fn to_i64(&self) -> Option<i64> { self.to_f32().to_i64() }
-    fn to_u64(&self) -> Option<u64> { self.to_f32().to_i64() }
-    fn to_i8(&self) -> Option<i8> { self.to_f32().to_i8() }
-    fn to_u8(&self) -> Option<u8> { self.to_f32().to_u8() }
-    fn to_i16(&self) -> Option<i16> { self.to_f32().to_i16() }
-    fn to_u16(&self) -> Option<u16> { self.to_f32().to_u16() }
-    fn to_i32(&self) -> Option<i32> { self.to_f32().to_i32() }
-    fn to_u32(&self) -> Option<u32> { self.to_f32().to_u32() }
-    fn to_f32(&self) -> Option<f32> { Some(self.to_f32()) }
-    fn to_f64(&self) -> Option<f32> { Some(self.to_f64()) }
-}
-
-#[cfg(feature = "num-traits")]
-impl FromPrimitive for f16 {
-    fn from_i64(n: i64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_u64(n: u64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_i8(n: i8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_u8(n: u8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_i16(n: i16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_u16(n: u16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_i32(n: i32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
-    fn from_u32(n: u32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    impl FromPrimitive for f16 {
+        fn from_i64(n: i64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_u64(n: u64) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_i8(n: i8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_u8(n: u8) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_i16(n: i16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_u16(n: u16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_i32(n: i32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_u32(n: u32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+    }
 }
 
 #[deprecated(

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -54,6 +54,8 @@ mod impl_num_traits {
         fn from_u16(n: u16) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
         fn from_i32(n: i32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
         fn from_u32(n: u32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_f32(n: f32) -> Option<Self> { n.to_f32().map(|x| Self::from_f32(x)) }
+        fn from_f64(n: f64) -> Option<Self> { n.to_f64().map(|x| Self::from_f64(x)) }
     }
 }
 


### PR DESCRIPTION
Adds optional support for num-traits ToPrimitive / FromPrimitive. This makes it easier to use bf16 and f16 interchangeably with f32. 