### PR TITLE
Implement Bounded trait for bf16 and f16

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ not have hardware support. **Available only on Rust nightly channel.**
   Enabling the `std` feature enables runtime CPU feature detection when the `use-intrsincis` feature is also enabled.
   Without this feature detection, intrinsics are only used when compiler host target supports them.
 
-- **`num-traits`** - Enable `ToPrimitive`, `FromPrimitive`, `Num`, `Float`, and `FloatCore` trait implementations from the
-  `num-traits` crate.
+- **`num-traits`** - Enable `ToPrimitive`, `FromPrimitive`, `Num`, `Float`, `FloatCore` and `Bounded` trait implementations
+  from the `num-traits` crate.
 
 - **`bytemuck`** - Enable `Zeroable` and `Pod` trait implementations from the `bytemuck` crate.
 

--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -654,7 +654,8 @@ mod impl_num_traits {
     use core::ops::{Div, Neg, Rem, Sub};
     use num_traits::float::FloatCore;
     use num_traits::{
-        AsPrimitive, Float, FloatConst, FromPrimitive, Num, NumCast, One, ToPrimitive, Zero,
+        AsPrimitive, Bounded, Float, FloatConst, FromPrimitive, Num, NumCast, One, ToPrimitive,
+        Zero,
     };
 
     impl ToPrimitive for bf16 {
@@ -1250,6 +1251,16 @@ mod impl_num_traits {
             Self: Sized + Div<Self, Output = Self>,
         {
             Self::LOG2_10
+        }
+    }
+
+    impl Bounded for bf16 {
+        fn min_value() -> Self {
+            bf16::MIN
+        }
+
+        fn max_value() -> Self {
+            bf16::MAX
         }
     }
 

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -41,7 +41,8 @@ mod impl_num_traits {
     use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
     use num_traits::float::FloatCore;
     use num_traits::{
-        AsPrimitive, Float, FloatConst, FromPrimitive, Num, NumCast, One, ToPrimitive, Zero,
+        AsPrimitive, Bounded, Float, FloatConst, FromPrimitive, Num, NumCast, One, ToPrimitive,
+        Zero,
     };
 
     impl ToPrimitive for f16 {
@@ -637,6 +638,16 @@ mod impl_num_traits {
             Self: Sized + Div<Self, Output = Self>,
         {
             Self::LOG2_10
+        }
+    }
+
+    impl Bounded for f16 {
+        fn min_value() -> Self {
+            f16::MIN
+        }
+
+        fn max_value() -> Self {
+            f16::MAX
         }
     }
 


### PR DESCRIPTION
This implements trait [`Bounded`](https://docs.rs/num/0.4.0/num/traits/trait.Bounded.html) for `bf16` and `f16` as the `num-traits` crate implements it for [`f32`](https://github.com/rust-num/num-traits/blob/305532d737f966ea449be2c0f67f575bc66b19a5/src/bounds.rs#L84) and [`f64`](https://github.com/rust-num/num-traits/blob/305532d737f966ea449be2c0f67f575bc66b19a5/src/bounds.rs#L117).