### PR TITLE
Add `impl Neg` for references

### DIFF
--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -838,6 +838,15 @@ impl Neg for bf16 {
     }
 }
 
+impl Neg for &bf16 {
+    type Output = <bf16 as Neg>::Output;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        Neg::neg(*self)
+    }
+}
+
 impl Add for bf16 {
     type Output = Self;
 

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -848,6 +848,15 @@ impl Neg for f16 {
     }
 }
 
+impl Neg for &f16 {
+    type Output = <f16 as Neg>::Output;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        Neg::neg(*self)
+    }
+}
+
 impl Add for f16 {
     type Output = Self;
 


### PR DESCRIPTION
Since it was missing and all the other numeric traits had reference versions.