### PR TITLE
Fix unique reference obtained from shared reference 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,3 +55,24 @@ jobs:
       with:
         command: make
         args: ci-flow
+
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: miri
+      - name: Run Miri
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -311,7 +311,7 @@ impl HalfFloatSliceExt for [f16] {
 
     #[inline]
     fn reinterpret_cast_mut(&mut self) -> &mut [u16] {
-        let pointer = self.as_ptr() as *mut u16;
+        let pointer = self.as_mut_ptr().cast::<u16>();
         let length = self.len();
         // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
         // and the size of elements are identical
@@ -465,7 +465,7 @@ impl HalfFloatSliceExt for [bf16] {
 
     #[inline]
     fn reinterpret_cast_mut(&mut self) -> &mut [u16] {
-        let pointer = self.as_ptr() as *mut u16;
+        let pointer = self.as_mut_ptr().cast::<u16>();
         let length = self.len();
         // SAFETY: We are reconstructing full length of original slice, using its same lifetime,
         // and the size of elements are identical


### PR DESCRIPTION
`slice.as_ptr` goes through a `&[T]`, which only gives it permission to read and not write. Fix it by using `as_mut_ptr` instead.

Also add miri with `MIRIFLAGS=-Zmiri-strict-provenance` to CI.