### PR TITLE
Implemented type coercion train from num traits branch for half

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bytemuck = { version = "1.4.1", default-features = false, features = [
 serde = { version = "1.0", default-features = false, features = [
     "derive",
 ], optional = true }
-num-traits = { version = "0.2.14", default-features = false, features = ["libm"], optional = true }
+num-traits = {git = "https://github.com/zommiommy/num-traits.git", default-features = false, features = ["libm"], optional = true }
 zerocopy = { version = "0.6.0", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "spirv")'.dependencies]


### PR DESCRIPTION
Hello, and thank you for making this crate!

I needed a trait for coercing (using the `as` conversion, with all its limitations and perks) between float values, and therefore I have added the trait `Coerced` that does just that. Since I needed this also for your lovely `f16` implementation, I have implemented them for `f16` and `bf16`.

_Disclaimer N1: [I have just made my pull request on num-traits](https://github.com/rust-num/num-traits/pull/244), so it will take time before they accept it (if they do at all). I have made this pull request to avoid forgetting about it._ 
_Disclaimer N2: I am still quite inexperienced with Rust, so feel absolutely free to change anything and/or prune this pull request_