### PR TITLE
Add `#[inline]` on fallback functions

### DIFF
--- a/src/bfloat/convert.rs
+++ b/src/bfloat/convert.rs
@@ -1,6 +1,7 @@
 use crate::leading_zeros::leading_zeros_u16;
 use core::mem;
 
+#[inline]
 pub(crate) const fn f32_to_bf16(value: f32) -> u16 {
     // TODO: Replace mem::transmute with to_bits() once to_bits is const-stabilized
     // Convert to raw bytes
@@ -21,6 +22,7 @@ pub(crate) const fn f32_to_bf16(value: f32) -> u16 {
     }
 }
 
+#[inline]
 pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
     // TODO: Replace mem::transmute with to_bits() once to_bits is const-stabilized
     // Convert to raw bytes, truncating the last 32-bits of mantissa; that precision will always
@@ -88,6 +90,7 @@ pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
     }
 }
 
+#[inline]
 pub(crate) const fn bf16_to_f32(i: u16) -> f32 {
     // TODO: Replace mem::transmute with from_bits() once from_bits is const-stabilized
     // If NaN, keep current mantissa but also set most significiant mantissa bit
@@ -98,6 +101,7 @@ pub(crate) const fn bf16_to_f32(i: u16) -> f32 {
     }
 }
 
+#[inline]
 pub(crate) const fn bf16_to_f64(i: u16) -> f64 {
     // TODO: Replace mem::transmute with from_bits() once from_bits is const-stabilized
     // Check for signed zero

--- a/src/binary16/convert.rs
+++ b/src/binary16/convert.rs
@@ -143,6 +143,7 @@ convert_fn! {
 // which can be simplified into
 //     (mantissa & round_bit) != 0 && (mantissa & (3 * round_bit - 1)) != 0
 
+#[inline]
 pub(crate) const fn f32_to_f16_fallback(value: f32) -> u16 {
     // TODO: Replace mem::transmute with to_bits() once to_bits is const-stabilized
     // Convert to raw bytes
@@ -203,6 +204,7 @@ pub(crate) const fn f32_to_f16_fallback(value: f32) -> u16 {
     }
 }
 
+#[inline]
 pub(crate) const fn f64_to_f16_fallback(value: f64) -> u16 {
     // Convert to raw bytes, truncating the last 32-bits of mantissa; that precision will always
     // be lost on half-precision.
@@ -270,6 +272,7 @@ pub(crate) const fn f64_to_f16_fallback(value: f64) -> u16 {
     }
 }
 
+#[inline]
 pub(crate) const fn f16_to_f32_fallback(i: u16) -> f32 {
     // Check for signed zero
     // TODO: Replace mem::transmute with from_bits() once from_bits is const-stabilized
@@ -316,6 +319,7 @@ pub(crate) const fn f16_to_f32_fallback(i: u16) -> f32 {
     unsafe { mem::transmute(sign | exp | man) }
 }
 
+#[inline]
 pub(crate) const fn f16_to_f64_fallback(i: u16) -> f64 {
     // Check for signed zero
     // TODO: Replace mem::transmute with from_bits() once from_bits is const-stabilized


### PR DESCRIPTION
I've been inspecting the stack traces in a profiler and noticed that the fallback conversion functions are not inlined.

The `#[inline]` attribute in Rust is [not transitive](https://matklad.github.io/2021/07/09/inline-in-rust.html), and the fallbacks will not be inlined if they are not marked `#[inline]` explicitly. 

I've verified that everything in the call stack up to this point is already marked `#[inline]`.