### PR TITLE
derive kani::Arbitrary on f16 and bf16

### DIFF
--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -35,6 +35,7 @@ pub(crate) mod convert;
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
 #[cfg_attr(feature = "zerocopy", derive(AsBytes, FromBytes))]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct bf16(u16);
 
 impl bf16 {

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -34,6 +34,7 @@ pub(crate) mod arch;
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
 #[cfg_attr(feature = "zerocopy", derive(AsBytes, FromBytes))]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct f16(u16);
 
 impl f16 {


### PR DESCRIPTION
Hi, thanks for the great library :grin: 

I've been using [kani](https://github.com/model-checking/kani) to introduce some lightweight formal methods for a CBOR implementation I'm working on. 

Kani has a trait `Arbitrary` which is used to generate symbolic values in the model checker (conceptually, a value that represents "for all `T`s").

The rough motivation for this PR is an enum that looks like:
```rust
#[cfg_attr(kani, derive(kani::Arbitrary))]
enum Float {
  Half(half::f16),
  Single(f32),
  Double(f64),
}
```
This currently fails, since `half::f16` doesn't implement `kani::Arbitrary`. This PR adds the derive macros, gated behind the `kani` compiler option being set. This doesn't add a cargo feature flag or optional dependency, since kani doesn't require this (when you verify a program, it compiles it with its own standard library, which injects the `kani` dependency).

I appreciate you may not want this sort of tool in the codebase, since it's fairly non-standard Rust, and could be unexpected/confusing for contributors, but FWIW, I've had very positive experiences with it. Happy to be given pushback on this though :sweat_smile: .

Usually I'd open an issue for this sort of thing first, but since the PR is so trivial, I thought it might just be easier this way.

Thanks :grin: 
