### PR TITLE
More #[inline] in HalfFloatSliceExt, leading_zeros

### DIFF
--- a/src/leading_zeros.rs
+++ b/src/leading_zeros.rs
@@ -7,6 +7,7 @@
         target_feature = "SPV_INTEL_shader_integer_functions2"
     ))
 ))))]
+#[inline]
 pub(crate) const fn leading_zeros_u16(x: u16) -> u32 {
     x.leading_zeros()
 }
@@ -18,6 +19,7 @@ pub(crate) const fn leading_zeros_u16(x: u16) -> u32 {
         target_feature = "SPV_INTEL_shader_integer_functions2"
     ))
 ))]
+#[inline]
 pub(crate) const fn leading_zeros_u16(x: u16) -> u32 {
     leading_zeros_u16_fallback(x)
 }
@@ -32,6 +34,7 @@ pub(crate) const fn leading_zeros_u16(x: u16) -> u32 {
         ))
     )
 ))]
+#[inline]
 const fn leading_zeros_u16_fallback(mut x: u16) -> u32 {
     use crunchy::unroll;
     let mut c = 0;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -318,6 +318,7 @@ impl HalfFloatSliceExt for [f16] {
         unsafe { slice::from_raw_parts_mut(pointer, length) }
     }
 
+    #[inline]
     fn convert_from_f32_slice(&mut self, src: &[f32]) {
         assert_eq!(
             self.len(),
@@ -328,6 +329,7 @@ impl HalfFloatSliceExt for [f16] {
         arch::f32_to_f16_slice(src, self.reinterpret_cast_mut())
     }
 
+    #[inline]
     fn convert_from_f64_slice(&mut self, src: &[f64]) {
         assert_eq!(
             self.len(),
@@ -338,6 +340,7 @@ impl HalfFloatSliceExt for [f16] {
         arch::f64_to_f16_slice(src, self.reinterpret_cast_mut())
     }
 
+    #[inline]
     fn convert_to_f32_slice(&self, dst: &mut [f32]) {
         assert_eq!(
             self.len(),
@@ -348,6 +351,7 @@ impl HalfFloatSliceExt for [f16] {
         arch::f16_to_f32_slice(self.reinterpret_cast(), dst)
     }
 
+    #[inline]
     fn convert_to_f64_slice(&self, dst: &mut [f64]) {
         assert_eq!(
             self.len(),
@@ -404,6 +408,7 @@ impl HalfFloatSliceExt for [bf16] {
         unsafe { slice::from_raw_parts_mut(pointer, length) }
     }
 
+    #[inline]
     fn convert_from_f32_slice(&mut self, src: &[f32]) {
         assert_eq!(
             self.len(),
@@ -417,6 +422,7 @@ impl HalfFloatSliceExt for [bf16] {
         }
     }
 
+    #[inline]
     fn convert_from_f64_slice(&mut self, src: &[f64]) {
         assert_eq!(
             self.len(),
@@ -430,6 +436,7 @@ impl HalfFloatSliceExt for [bf16] {
         }
     }
 
+    #[inline]
     fn convert_to_f32_slice(&self, dst: &mut [f32]) {
         assert_eq!(
             self.len(),
@@ -443,6 +450,7 @@ impl HalfFloatSliceExt for [bf16] {
         }
     }
 
+    #[inline]
     fn convert_to_f64_slice(&self, dst: &mut [f64]) {
         assert_eq!(
             self.len(),


### PR DESCRIPTION
This helps code generation for situations with fixed size arrays:
```rust
let src: [f16; 4];
let mut dst = [0f32; 4];
src.convert_to_f32_slice(&mut dst);
// ^ This will get optimized to a direct f16x4_to_f32x4
```
Without the inline modifier, `convert_to_f32_slice` is always generated as a generic function across arbitrary length slices.