### PR TITLE
Adds rand_distr::Distribution implementations for f16 & bf16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,4 @@ harness = false
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]
-features = ["std", "serde", "bytemuck", "num-traits", "zerocopy", "rand_distr"]
+features = ["std", "serde", "bytemuck", "num-traits", "zerocopy", "rand", "rand_distr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = ["std"]
 std = ["alloc"]
 use-intrinsics = []
 alloc = []
+rand_distr = ["dep:rand", "dep:rand_distr"]
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [".git*", ".editorconfig"]
 
 [features]
 default = ["std"]
+sample = ["rand", "rand_distr"]
 std = ["alloc"]
 use-intrinsics = []
 alloc = []
@@ -29,6 +30,8 @@ serde = { version = "1.0", default-features = false, features = [
 ], optional = true }
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"], optional = true }
 zerocopy = { version = "0.6.0", default-features = false, optional = true }
+rand = { version = "0.8.5", default-features = false, optional = true }
+rand_distr = { version = "0.4.3", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "spirv")'.dependencies]
 crunchy = "0.2.2"
@@ -37,7 +40,7 @@ crunchy = "0.2.2"
 criterion = "0.4.0"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
-rand = "0.8.4"
+rand = "0.8.5"
 crunchy = "0.2.2"
 
 [[bench]]
@@ -46,4 +49,4 @@ harness = false
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]
-features = ["std", "serde", "bytemuck", "num-traits", "zerocopy"]
+features = ["std", "serde", "bytemuck", "num-traits", "zerocopy", "sample"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [".git*", ".editorconfig"]
 
 [features]
 default = ["std"]
-sample = ["rand", "rand_distr"]
 std = ["alloc"]
 use-intrinsics = []
 alloc = []
@@ -49,4 +48,4 @@ harness = false
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]
-features = ["std", "serde", "bytemuck", "num-traits", "zerocopy", "sample"]
+features = ["std", "serde", "bytemuck", "num-traits", "zerocopy", "rand_distr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,4 @@ harness = false
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]
-features = ["std", "serde", "bytemuck", "num-traits", "zerocopy", "rand", "rand_distr"]
+features = ["std", "serde", "bytemuck", "num-traits", "zerocopy", "rand_distr"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,7 +5,7 @@ min_version = "0.35.0"
 CI_CARGO_TEST_FLAGS = { value = "--locked -- --nocapture", condition = { env_true = [
     "CARGO_MAKE_CI",
 ] } }
-CARGO_MAKE_CARGO_ALL_FEATURES = { source = "${CARGO_MAKE_RUST_CHANNEL}", default_value = "--features=std,serde,num-traits,bytemuck,zerocopy", mapping = { "nightly" = "--all-features" } }
+CARGO_MAKE_CARGO_ALL_FEATURES = { source = "${CARGO_MAKE_RUST_CHANNEL}", default_value = "--features=std,serde,num-traits,bytemuck,zerocopy,rand_distr", mapping = { "nightly" = "--all-features" } }
 CARGO_MAKE_CLIPPY_ARGS = { value = "${CARGO_MAKE_CLIPPY_ALL_FEATURES_WARN}", condition = { env_true = [
     "CARGO_MAKE_CI",
 ] } }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,7 +5,7 @@ min_version = "0.35.0"
 CI_CARGO_TEST_FLAGS = { value = "--locked -- --nocapture", condition = { env_true = [
     "CARGO_MAKE_CI",
 ] } }
-CARGO_MAKE_CARGO_ALL_FEATURES = { source = "${CARGO_MAKE_RUST_CHANNEL}", default_value = "--features=std,serde,num-traits,bytemuck,zerocopy,rand,rand_distr", mapping = { "nightly" = "--all-features" } }
+CARGO_MAKE_CARGO_ALL_FEATURES = { source = "${CARGO_MAKE_RUST_CHANNEL}", default_value = "--features=std,serde,num-traits,bytemuck,zerocopy,rand_distr", mapping = { "nightly" = "--all-features" } }
 CARGO_MAKE_CLIPPY_ARGS = { value = "${CARGO_MAKE_CLIPPY_ALL_FEATURES_WARN}", condition = { env_true = [
     "CARGO_MAKE_CI",
 ] } }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,7 +5,7 @@ min_version = "0.35.0"
 CI_CARGO_TEST_FLAGS = { value = "--locked -- --nocapture", condition = { env_true = [
     "CARGO_MAKE_CI",
 ] } }
-CARGO_MAKE_CARGO_ALL_FEATURES = { source = "${CARGO_MAKE_RUST_CHANNEL}", default_value = "--features=std,serde,num-traits,bytemuck,zerocopy,rand_distr", mapping = { "nightly" = "--all-features" } }
+CARGO_MAKE_CARGO_ALL_FEATURES = { source = "${CARGO_MAKE_RUST_CHANNEL}", default_value = "--features=std,serde,num-traits,bytemuck,zerocopy,rand,rand_distr", mapping = { "nightly" = "--all-features" } }
 CARGO_MAKE_CLIPPY_ARGS = { value = "${CARGO_MAKE_CLIPPY_ALL_FEATURES_WARN}", condition = { env_true = [
     "CARGO_MAKE_CI",
 ] } }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ See the [crate documentation](https://docs.rs/half/) for more details.
 - **`zerocopy`** — Enable `AsBytes` and `FromBytes` trait implementations from the 
   [`zerocopy`](https://crates.io/crates/zerocopy) crate.
 
+- **`rand_distr`** — Enable sampling from distributions like `Uniform` and `Normal` from the
+  [`rand_distr`](https://crates.io/crates/rand_distr) crate.
+
 ### Hardware support
 
 The following list details hardware support for floating point types in this crate. When using `std`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //! - **`zerocopy`** — Adds support for the [`zerocopy`] crate by implementing [`AsBytes`] and
 //!   [`FromBytes`] traits for both [`f16`] and [`bf16`].
 //!
-//! - **`rand_distr`** — Adds support for the [`rand_distr`] crate by implementing [`Distribution`]
+//! - **`rand_distr`** — Adds support for the [`rand_distr`] crate by implementing [`rand::distributions::Distribution`]
 //!   and other traits for both [`f16`] and [`bf16`].
 //!
 //! [`alloc`]: https://doc.rust-lang.org/alloc/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,9 @@ pub mod vec;
 pub use bfloat::bf16;
 pub use binary16::f16;
 
+#[cfg(feature = "sample")]
+mod sample;
+
 /// A collection of the most used items and traits in this crate for easy importing.
 ///
 /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@
 //! - **`zerocopy`** — Adds support for the [`zerocopy`] crate by implementing [`AsBytes`] and
 //!   [`FromBytes`] traits for both [`f16`] and [`bf16`].
 //!
+//! - **`rand_distr`** — Adds support for the [`rand_distr`] crate by implementing [`Distribution`]
+//!   and other traits for both [`f16`] and [`bf16`].
+//!
 //! [`alloc`]: https://doc.rust-lang.org/alloc/
 //! [`std`]: https://doc.rust-lang.org/std/
 //! [`binary16`]: https://en.wikipedia.org/wiki/Half-precision_floating-point_format
@@ -102,6 +105,7 @@
 //! [`bytemuck`]: https://crates.io/crates/bytemuck
 //! [`num-traits`]: https://crates.io/crates/num-traits
 //! [`zerocopy`]: https://crates.io/crates/zerocopy
+//! [`rand_distr`]: https://crates.io/crates/rand_distr
 #![cfg_attr(
     feature = "alloc",
     doc = "
@@ -209,8 +213,8 @@ pub mod vec;
 pub use bfloat::bf16;
 pub use binary16::f16;
 
-#[cfg(feature = "sample")]
-mod sample;
+#[cfg(feature = "rand_distr")]
+mod rand_distr;
 
 /// A collection of the most used items and traits in this crate for easy importing.
 ///

--- a/src/rand_distr.rs
+++ b/src/rand_distr.rs
@@ -94,20 +94,21 @@ impl rand_distr::uniform::UniformSampler for BFloat16Sampler {
 }
 
 #[cfg(test)]
-#[cfg(feature = "num-traits")]
 mod tests {
     use super::*;
 
     use rand::{thread_rng, Rng};
-    use rand_distr::{Normal, Standard, StandardNormal, Uniform};
+    use rand_distr::{Standard, StandardNormal, Uniform};
 
     #[test]
     fn test_sample_f16() {
         let mut rng = thread_rng();
         let _: f16 = rng.sample(Standard);
         let _: f16 = rng.sample(StandardNormal);
-        let _: f16 = rng.sample(Normal::new(f16::from_f32(0.0), f16::from_f32(1.0)).unwrap());
         let _: f16 = rng.sample(Uniform::new(f16::from_f32(0.0), f16::from_f32(1.0)));
+        #[cfg(feature = "num-traits")]
+        let _: f16 =
+            rng.sample(rand_distr::Normal::new(f16::from_f32(0.0), f16::from_f32(1.0)).unwrap());
     }
 
     #[test]
@@ -115,7 +116,9 @@ mod tests {
         let mut rng = thread_rng();
         let _: bf16 = rng.sample(Standard);
         let _: bf16 = rng.sample(StandardNormal);
-        let _: bf16 = rng.sample(Normal::new(bf16::from_f32(0.0), bf16::from_f32(1.0)).unwrap());
         let _: bf16 = rng.sample(Uniform::new(bf16::from_f32(0.0), bf16::from_f32(1.0)));
+        #[cfg(feature = "num-traits")]
+        let _: bf16 =
+            rng.sample(rand_distr::Normal::new(bf16::from_f32(0.0), bf16::from_f32(1.0)).unwrap());
     }
 }

--- a/src/rand_distr.rs
+++ b/src/rand_distr.rs
@@ -1,5 +1,7 @@
-use rand::Rng;
-use rand_distr::{uniform::UniformFloat, Distribution};
+use crate::{bf16, f16};
+
+use rand::{distributions::Distribution, Rng};
+use rand_distr::uniform::UniformFloat;
 
 macro_rules! impl_distribution_via_f32 {
     ($Ty:ty, $Distr:ty) => {
@@ -11,27 +13,27 @@ macro_rules! impl_distribution_via_f32 {
     };
 }
 
-impl_distribution_via_f32!(crate::f16, rand_distr::Standard);
-impl_distribution_via_f32!(crate::f16, rand_distr::StandardNormal);
-impl_distribution_via_f32!(crate::f16, rand_distr::Exp1);
-impl_distribution_via_f32!(crate::f16, rand_distr::Open01);
-impl_distribution_via_f32!(crate::f16, rand_distr::OpenClosed01);
+impl_distribution_via_f32!(f16, rand_distr::Standard);
+impl_distribution_via_f32!(f16, rand_distr::StandardNormal);
+impl_distribution_via_f32!(f16, rand_distr::Exp1);
+impl_distribution_via_f32!(f16, rand_distr::Open01);
+impl_distribution_via_f32!(f16, rand_distr::OpenClosed01);
 
-impl_distribution_via_f32!(crate::bf16, rand_distr::Standard);
-impl_distribution_via_f32!(crate::bf16, rand_distr::StandardNormal);
-impl_distribution_via_f32!(crate::bf16, rand_distr::Exp1);
-impl_distribution_via_f32!(crate::bf16, rand_distr::Open01);
-impl_distribution_via_f32!(crate::bf16, rand_distr::OpenClosed01);
+impl_distribution_via_f32!(bf16, rand_distr::Standard);
+impl_distribution_via_f32!(bf16, rand_distr::StandardNormal);
+impl_distribution_via_f32!(bf16, rand_distr::Exp1);
+impl_distribution_via_f32!(bf16, rand_distr::Open01);
+impl_distribution_via_f32!(bf16, rand_distr::OpenClosed01);
 
 #[derive(Debug, Clone, Copy)]
 pub struct Float16Sampler(UniformFloat<f32>);
 
-impl rand_distr::uniform::SampleUniform for crate::f16 {
+impl rand_distr::uniform::SampleUniform for f16 {
     type Sampler = Float16Sampler;
 }
 
 impl rand_distr::uniform::UniformSampler for Float16Sampler {
-    type X = crate::f16;
+    type X = f16;
     fn new<B1, B2>(low: B1, high: B2) -> Self
     where
         B1: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
@@ -53,19 +55,19 @@ impl rand_distr::uniform::UniformSampler for Float16Sampler {
         ))
     }
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
-        crate::f16::from_f32(self.0.sample(rng))
+        f16::from_f32(self.0.sample(rng))
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct BFloat16Sampler(UniformFloat<f32>);
 
-impl rand_distr::uniform::SampleUniform for crate::bf16 {
+impl rand_distr::uniform::SampleUniform for bf16 {
     type Sampler = BFloat16Sampler;
 }
 
 impl rand_distr::uniform::UniformSampler for BFloat16Sampler {
-    type X = crate::bf16;
+    type X = bf16;
     fn new<B1, B2>(low: B1, high: B2) -> Self
     where
         B1: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
@@ -87,40 +89,33 @@ impl rand_distr::uniform::UniformSampler for BFloat16Sampler {
         ))
     }
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
-        crate::bf16::from_f32(self.0.sample(rng))
+        bf16::from_f32(self.0.sample(rng))
     }
 }
 
 #[cfg(test)]
+#[cfg(feature = "num-traits")]
 mod tests {
+    use super::*;
+
     use rand::{thread_rng, Rng};
+    use rand_distr::{Normal, Standard, StandardNormal, Uniform};
 
     #[test]
     fn test_sample_f16() {
         let mut rng = thread_rng();
-        let _: crate::f16 = rng.sample(rand_distr::Standard);
-        let _: crate::f16 = rng.sample(rand_distr::StandardNormal);
-        let _: crate::f16 = rng.sample(
-            rand_distr::Normal::new(crate::f16::from_f32(0.0), crate::f16::from_f32(1.0)).unwrap(),
-        );
-        let _: crate::f16 = rng.sample(rand_distr::Uniform::new(
-            crate::f16::from_f32(0.0),
-            crate::f16::from_f32(1.0),
-        ));
+        let _: f16 = rng.sample(Standard);
+        let _: f16 = rng.sample(StandardNormal);
+        let _: f16 = rng.sample(Normal::new(f16::from_f32(0.0), f16::from_f32(1.0)).unwrap());
+        let _: f16 = rng.sample(Uniform::new(f16::from_f32(0.0), f16::from_f32(1.0)));
     }
 
     #[test]
     fn test_sample_bf16() {
         let mut rng = thread_rng();
-        let _: crate::bf16 = rng.sample(rand_distr::Standard);
-        let _: crate::bf16 = rng.sample(rand_distr::StandardNormal);
-        let _: crate::bf16 = rng.sample(
-            rand_distr::Normal::new(crate::bf16::from_f32(0.0), crate::bf16::from_f32(1.0))
-                .unwrap(),
-        );
-        let _: crate::bf16 = rng.sample(rand_distr::Uniform::new(
-            crate::bf16::from_f32(0.0),
-            crate::bf16::from_f32(1.0),
-        ));
+        let _: bf16 = rng.sample(Standard);
+        let _: bf16 = rng.sample(StandardNormal);
+        let _: bf16 = rng.sample(Normal::new(bf16::from_f32(0.0), bf16::from_f32(1.0)).unwrap());
+        let _: bf16 = rng.sample(Uniform::new(bf16::from_f32(0.0), bf16::from_f32(1.0)));
     }
 }

--- a/src/rand_distr.rs
+++ b/src/rand_distr.rs
@@ -1,9 +1,10 @@
+use rand::Rng;
 use rand_distr::{uniform::UniformFloat, Distribution};
 
 macro_rules! impl_distribution_via_f32 {
     ($Ty:ty, $Distr:ty) => {
         impl Distribution<$Ty> for $Distr {
-            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> $Ty {
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $Ty {
                 <$Ty>::from_f32(<Self as Distribution<f32>>::sample(self, rng))
             }
         }
@@ -51,7 +52,7 @@ impl rand_distr::uniform::UniformSampler for Float16Sampler {
             high.borrow().to_f32(),
         ))
     }
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
         crate::f16::from_f32(self.0.sample(rng))
     }
 }
@@ -85,7 +86,7 @@ impl rand_distr::uniform::UniformSampler for BFloat16Sampler {
             high.borrow().to_f32(),
         ))
     }
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
         crate::bf16::from_f32(self.0.sample(rng))
     }
 }

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,0 +1,125 @@
+use rand_distr::{uniform::UniformFloat, Distribution};
+
+macro_rules! impl_distribution_via_f32 {
+    ($Ty:ty, $Distr:ty) => {
+        impl Distribution<$Ty> for $Distr {
+            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> $Ty {
+                <$Ty>::from_f32(<Self as Distribution<f32>>::sample(self, rng))
+            }
+        }
+    };
+}
+
+impl_distribution_via_f32!(crate::f16, rand_distr::Standard);
+impl_distribution_via_f32!(crate::f16, rand_distr::StandardNormal);
+impl_distribution_via_f32!(crate::f16, rand_distr::Exp1);
+impl_distribution_via_f32!(crate::f16, rand_distr::Open01);
+impl_distribution_via_f32!(crate::f16, rand_distr::OpenClosed01);
+
+impl_distribution_via_f32!(crate::bf16, rand_distr::Standard);
+impl_distribution_via_f32!(crate::bf16, rand_distr::StandardNormal);
+impl_distribution_via_f32!(crate::bf16, rand_distr::Exp1);
+impl_distribution_via_f32!(crate::bf16, rand_distr::Open01);
+impl_distribution_via_f32!(crate::bf16, rand_distr::OpenClosed01);
+
+#[derive(Debug, Clone, Copy)]
+pub struct Float16Sampler(UniformFloat<f32>);
+
+impl rand_distr::uniform::SampleUniform for crate::f16 {
+    type Sampler = Float16Sampler;
+}
+
+impl rand_distr::uniform::UniformSampler for Float16Sampler {
+    type X = crate::f16;
+    fn new<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
+        B2: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
+    {
+        Self(UniformFloat::new(
+            low.borrow().to_f32(),
+            high.borrow().to_f32(),
+        ))
+    }
+    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
+        B2: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
+    {
+        Self(UniformFloat::new_inclusive(
+            low.borrow().to_f32(),
+            high.borrow().to_f32(),
+        ))
+    }
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+        crate::f16::from_f32(self.0.sample(rng))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BFloat16Sampler(UniformFloat<f32>);
+
+impl rand_distr::uniform::SampleUniform for crate::bf16 {
+    type Sampler = BFloat16Sampler;
+}
+
+impl rand_distr::uniform::UniformSampler for BFloat16Sampler {
+    type X = crate::bf16;
+    fn new<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
+        B2: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
+    {
+        Self(UniformFloat::new(
+            low.borrow().to_f32(),
+            high.borrow().to_f32(),
+        ))
+    }
+    fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+    where
+        B1: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
+        B2: rand_distr::uniform::SampleBorrow<Self::X> + Sized,
+    {
+        Self(UniformFloat::new_inclusive(
+            low.borrow().to_f32(),
+            high.borrow().to_f32(),
+        ))
+    }
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+        crate::bf16::from_f32(self.0.sample(rng))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{thread_rng, Rng};
+
+    #[test]
+    fn test_sample_f16() {
+        let mut rng = thread_rng();
+        let _: crate::f16 = rng.sample(rand_distr::Standard);
+        let _: crate::f16 = rng.sample(rand_distr::StandardNormal);
+        let _: crate::f16 = rng.sample(
+            rand_distr::Normal::new(crate::f16::from_f32(0.0), crate::f16::from_f32(1.0)).unwrap(),
+        );
+        let _: crate::f16 = rng.sample(rand_distr::Uniform::new(
+            crate::f16::from_f32(0.0),
+            crate::f16::from_f32(1.0),
+        ));
+    }
+
+    #[test]
+    fn test_sample_bf16() {
+        let mut rng = thread_rng();
+        let _: crate::bf16 = rng.sample(rand_distr::Standard);
+        let _: crate::bf16 = rng.sample(rand_distr::StandardNormal);
+        let _: crate::bf16 = rng.sample(
+            rand_distr::Normal::new(crate::bf16::from_f32(0.0), crate::bf16::from_f32(1.0))
+                .unwrap(),
+        );
+        let _: crate::bf16 = rng.sample(rand_distr::Uniform::new(
+            crate::bf16::from_f32(0.0),
+            crate::bf16::from_f32(1.0),
+        ));
+    }
+}


### PR DESCRIPTION
Resolves #82 

Tests need to be run with the `sample` and `num-traits` feature enabled