### PR TITLE
Adding `From<f32>`/`From<f64>` impls for `f16`/`bf16`

### DIFF
--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -787,10 +787,24 @@ impl From<bf16> for f32 {
     }
 }
 
+impl From<f32> for bf16 {
+    #[inline]
+    fn from(x: f32) -> bf16 {
+        bf16::from_f32(x)
+    }
+}
+
 impl From<bf16> for f64 {
     #[inline]
     fn from(x: bf16) -> f64 {
         x.to_f64()
+    }
+}
+
+impl From<f64> for bf16 {
+    #[inline]
+    fn from(x: f64) -> bf16 {
+        bf16::from_f64(x)
     }
 }
 

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -797,10 +797,24 @@ impl From<f16> for f32 {
     }
 }
 
+impl From<f32> for f16 {
+    #[inline]
+    fn from(x: f32) -> f16 {
+        f16::from_f32(x)
+    }
+}
+
 impl From<f16> for f64 {
     #[inline]
     fn from(x: f16) -> f64 {
         x.to_f64()
+    }
+}
+
+impl From<f64> for f16 {
+    #[inline]
+    fn from(x: f64) -> f16 {
+        f16::from_f64(x)
     }
 }
 


### PR DESCRIPTION
This adds from/into in the other way than is currently present, making the following code possible:

```rust
use half::f16;

fn add_me(a: f16, b: impl Into<f16>) -> f16 {
    a + b.into()
}

fn main() {
    println!("{}", add_me(f16::ZERO, 2.0f32));
    println!("{}", add_me(f16::ZERO, 2.0f64));
    println!("{}", add_me(f16::ZERO, f16::from_f64(2.0f64)));
}
```