### PR TITLE
Fix Sum<&'a bf16> for bf16

### DIFF
--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -1259,7 +1259,7 @@ impl Sum for bf16 {
 impl<'a> Sum<&'a bf16> for bf16 {
     #[inline]
     fn sum<I: Iterator<Item = &'a bf16>>(iter: I) -> Self {
-        bf16::from_f32(iter.map(|f| f.to_f32()).product())
+        bf16::from_f32(iter.map(|f| f.to_f32()).sum())
     }
 }
 


### PR DESCRIPTION
The original implementation mistakenly computes the product. This pull request fixes this issue.