### PR TITLE
Add Into<f16> support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ std = ["alloc"]
 use-intrinsics = []
 alloc = []
 rand_distr = ["dep:rand", "dep:rand_distr"]
+into-f16 = []
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -780,6 +780,22 @@ impl bf16 {
     pub const SQRT_2: bf16 = bf16(0x3FB5u16);
 }
 
+#[cfg(feature = "into-f16")]
+impl From<f32> for bf16 {
+    #[inline]
+    fn from(x: f32) -> bf16 {
+        bf16::from_f32(x)
+    }
+}
+
+#[cfg(feature = "into-f16")]
+impl From<f64> for bf16 {
+    #[inline]
+    fn from(x: f64) -> bf16 {
+        bf16::from_f64(x)
+    }
+}
+
 impl From<bf16> for f32 {
     #[inline]
     fn from(x: bf16) -> f32 {

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -790,6 +790,22 @@ impl f16 {
     pub const SQRT_2: f16 = f16(0x3DA8u16);
 }
 
+#[cfg(feature = "into-f16")]
+impl From<f32> for f16 {
+    #[inline]
+    fn from(x: f32) -> f16 {
+        f16::from_f32(x)
+    }
+}
+
+#[cfg(feature = "into-f16")]
+impl From<f64> for f16 {
+    #[inline]
+    fn from(x: f64) -> f16 {
+        f16::from_f64(x)
+    }
+}
+
 impl From<f16> for f32 {
     #[inline]
     fn from(x: f16) -> f32 {


### PR DESCRIPTION
This PR adds support for `f32: Into<f16>` and `f64: Into<f16>`. For the sake of generics it would be nice to support this functionality. 

As mentioned in https://github.com/starkat99/half-rs/issues/69 this is lossy. For our specific use case we dont care about that, but others might so its behind a feature toggle.