### PR TITLE
Fixed not compiling for i686-pc-windows-msvc

### DIFF
--- a/src/binary16/arch/x86.rs
+++ b/src/binary16/arch/x86.rs
@@ -11,6 +11,9 @@ use core::arch::x86_64::{
     _MM_FROUND_TO_NEAREST_INT,
 };
 
+#[cfg(target_arch = "x86")]
+use core::arch::x86::_mm_cvtps_ph;
+
 use super::convert_chunked_slice_8;
 
 /////////////// x86/x86_64 f16c ////////////////


### PR DESCRIPTION
I was trying to compile this crate for the i686 arch and id did not seem to compile, because a import was missing, (maybe someone did not try to compile for all targets.) I added the import in an extra line, so you can see how you will proceed with this.
Kind regards