### PR TITLE
[Tentative] Adding new intrinsics for ggblas.

### DIFF
--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "zerocopy")]
 use zerocopy::{AsBytes, FromBytes};
 
-pub(crate) mod arch;
+pub mod arch;
 
 /// A 16-bit floating point type implementing the IEEE 754-2008 standard [`binary16`] a.k.a "half"
 /// format.

--- a/src/binary16/arch.rs
+++ b/src/binary16/arch.rs
@@ -6,7 +6,11 @@ use core::mem;
 mod x86;
 
 #[cfg(target_arch = "aarch64")]
-mod aarch64;
+pub mod aarch64;
+
+#[cfg(target_arch = "arm")]
+mod arm;
+
 
 macro_rules! convert_fn {
     (if x86_feature("f16c") { $f16c:expr }

--- a/src/binary16/arch/aarch64.rs
+++ b/src/binary16/arch/aarch64.rs
@@ -7,6 +7,117 @@ use core::{
     ptr,
 };
 
+use crate::f16;
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
+pub struct float16x8_t(pub(crate) u16, pub(crate) u16, pub(crate) u16, pub(crate) u16, pub(crate) u16, pub(crate) u16, pub(crate) u16, pub(crate) u16);
+
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy)]
+pub struct float16x4_t(pub(crate) u16, pub(crate) u16, pub(crate) u16, pub(crate) u16);
+
+#[target_feature(enable = "fp16")]
+#[inline]
+pub unsafe fn vcvt_f32_f16(i: float16x4_t) -> float32x4_t {
+    let result: float32x4_t;
+    asm!(
+        "fcvtl {0:v}.4s, {1:v}.4h",
+        out(vreg) result,
+        in(vreg) i,
+        options(pure, nomem, nostack, preserves_flags));
+    result
+}
+
+#[target_feature(enable = "fp16")]
+#[inline]
+pub unsafe fn vget_high_f16_f32(i: float16x8_t) -> float32x4_t {
+    let result: float32x4_t;
+    asm!(
+        "fcvtl2 {0:v}.4s, {1:v}.8h",
+        out(vreg) result,
+        in(vreg) i,
+        options(pure, nomem, nostack, preserves_flags));
+    result
+}
+
+#[target_feature(enable = "fp16")]
+#[inline]
+pub unsafe fn vget_low_f16_f32(i: float16x8_t) -> float32x4_t {
+    let result: float32x4_t;
+    asm!(
+        "fcvtl {0:v}.4s, {1:v}.4h",
+        out(vreg) result,
+        in(vreg) i,
+        options(pure, nomem, nostack, preserves_flags));
+    result
+}
+
+#[target_feature(enable = "fp16")]
+#[inline]
+pub unsafe fn vaddq_f16(a: float16x8_t, b: float16x8_t) -> float16x8_t {
+    let result: float16x8_t;
+    asm!(
+        "fadd {0:v}.8h, {1:v}.8h, {2:v}.8h",
+        out(vreg) result,
+        in(vreg) a,
+        in(vreg) b,
+        options(pure, nomem, nostack, preserves_flags));
+    result
+}
+
+#[target_feature(enable = "fp16")]
+#[inline]
+pub unsafe fn vst1q_f16(mut ptr: *mut f16, mut val: float16x8_t){
+    ptr::copy_nonoverlapping(&val, ptr.cast(), 8);
+    // asm!(
+    //     "vst1q_f16 {0:s}, {1:h}",
+    //     out(vreg) ptr,
+    //     in(vreg) val,
+    //     options(pure, nomem, nostack, preserves_flags));
+}
+
+#[target_feature(enable = "fp16")]
+#[inline]
+pub unsafe fn vld1q_f16(ptr: *const f16) -> float16x8_t{
+    let mut result = MaybeUninit::<float16x8_t>::uninit();
+    ptr::copy_nonoverlapping(ptr.cast(), &mut result, 8);
+    // asm!(
+    //     "vld1q_f16 {0:s}, {1:h}",
+    //     out(vreg) result,
+    //     in(vreg) ptr,
+    //     options(pure, nomem, nostack, preserves_flags));
+    result.assume_init()
+}
+
+#[target_feature(enable = "fp16")]
+#[inline]
+pub unsafe fn vfmaq_f16(a: float16x8_t, b: float16x8_t, c: float16x8_t) -> float16x8_t{
+    // let result: float16x8_t;
+    asm!(
+        "fmla {0:v}.8h, {1:v}.8h, {2:v}.8h",
+        in(vreg) a,
+        in(vreg) b,
+        in(vreg) c,
+        options(nomem, nostack, preserves_flags));
+    // result
+    a
+}
+
+#[target_feature(enable = "fp16")]
+#[inline]
+pub unsafe fn vdupq_n_f16(a: u16) -> float16x8_t{
+    let result: float16x8_t;
+    asm!(
+        "dup {0:v}.8h, {1:v}.h[0]",
+        out(vreg) result,
+        in(vreg) a,
+        options(pure, nomem, nostack, preserves_flags));
+    result
+}
+
 #[target_feature(enable = "fp16")]
 #[inline]
 pub(super) unsafe fn f16_to_f32_fp16(i: u16) -> f32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(repr_simd)]
 //! A crate that provides support for half-precision 16-bit floating point types.
 //!
 //! This crate provides the [`f16`] type, which is an implementation of the IEEE 754-2008 standard
@@ -201,11 +202,13 @@
 #![doc(test(attr(deny(warnings), allow(unused))))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
+
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod bfloat;
-mod binary16;
+pub mod binary16;
 mod leading_zeros;
 #[cfg(feature = "num-traits")]
 mod num_traits;


### PR DESCRIPTION
Hi here.

I am attempting to port basically ggml matrix multiplication into a standalone crate: https://github.com/Narsil/ggblas

For most of the operations, I was able to leverage intrinsics:  https://doc.rust-lang.org/core/arch/arm/index.html
However for M1 (so arm aarch64), it's missing some SIMD f16 intrinsics. 

https://developer.arm.com/documentation/101028/0012/13--Advanced-SIMD--Neon--intrinsics

Not sure if the approach I suggest here is viable, my understanding of low level primitives such as these is fairly limited.

Happy to run a more complete set of operations if this is indeed deemed interesting.

Seems the proper implementation into the compiler itself would be something like : https://github.com/rust-lang/stdarch/issues/344

That's why I felt the intrinsics would have their place here.

Cheers  !