### PR TITLE
Initialize vecs before set_len and check required array length.

### DIFF
--- a/src/binary16/convert.rs
+++ b/src/binary16/convert.rs
@@ -436,7 +436,7 @@ mod x86 {
     #[target_feature(enable = "f16c")]
     #[inline]
     pub(super) unsafe fn f16x4_to_f32x4_x86_f16c(v: &[u16]) -> [f32; 4] {
-        debug_assert!(v.len() >= 4);
+        assert!(v.len() >= 4);
 
         let mut vec = MaybeUninit::<__m128i>::zeroed();
         ptr::copy_nonoverlapping(v.as_ptr(), vec.as_mut_ptr().cast(), 4);
@@ -458,7 +458,7 @@ mod x86 {
     #[target_feature(enable = "f16c")]
     #[inline]
     pub(super) unsafe fn f16x4_to_f64x4_x86_f16c(v: &[u16]) -> [f64; 4] {
-        debug_assert!(v.len() >= 4);
+        assert!(v.len() >= 4);
 
         let mut vec = MaybeUninit::<__m128i>::zeroed();
         ptr::copy_nonoverlapping(v.as_ptr(), vec.as_mut_ptr().cast(), 4);
@@ -477,7 +477,7 @@ mod x86 {
     #[target_feature(enable = "f16c")]
     #[inline]
     pub(super) unsafe fn f64x4_to_f16x4_x86_f16c(v: &[f64]) -> [u16; 4] {
-        debug_assert!(v.len() >= 4);
+        assert!(v.len() >= 4);
 
         // Let compiler vectorize this regular cast for now.
         // TODO: investigate auto-detecting sse2/avx convert features

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -423,11 +423,7 @@ impl HalfFloatSliceExt for [f16] {
     #[cfg(any(feature = "alloc", feature = "std"))]
     #[inline]
     fn to_f32_vec(&self) -> Vec<f32> {
-        let mut vec = Vec::with_capacity(self.len());
-        // SAFETY: convert will initialize every value in the vector without reading them,
-        // so this is safe to do instead of double initialize from resize, and we're setting it to
-        // same value as capacity.
-        unsafe { vec.set_len(self.len()) };
+        let mut vec = vec![0f32; self.len()];
         self.convert_to_f32_slice(&mut vec);
         vec
     }
@@ -435,11 +431,7 @@ impl HalfFloatSliceExt for [f16] {
     #[cfg(any(feature = "alloc", feature = "std"))]
     #[inline]
     fn to_f64_vec(&self) -> Vec<f64> {
-        let mut vec = Vec::with_capacity(self.len());
-        // SAFETY: convert will initialize every value in the vector without reading them,
-        // so this is safe to do instead of double initialize from resize, and we're setting it to
-        // same value as capacity.
-        unsafe { vec.set_len(self.len()) };
+        let mut vec = vec![0f64; self.len()];
         self.convert_to_f64_slice(&mut vec);
         vec
     }
@@ -519,11 +511,7 @@ impl HalfFloatSliceExt for [bf16] {
     #[cfg(any(feature = "alloc", feature = "std"))]
     #[inline]
     fn to_f32_vec(&self) -> Vec<f32> {
-        let mut vec = Vec::with_capacity(self.len());
-        // SAFETY: convert will initialize every value in the vector without reading them,
-        // so this is safe to do instead of double initialize from resize, and we're setting it to
-        // same value as capacity.
-        unsafe { vec.set_len(self.len()) };
+        let mut vec = vec![0f32; self.len()];
         self.convert_to_f32_slice(&mut vec);
         vec
     }
@@ -531,11 +519,7 @@ impl HalfFloatSliceExt for [bf16] {
     #[cfg(any(feature = "alloc", feature = "std"))]
     #[inline]
     fn to_f64_vec(&self) -> Vec<f64> {
-        let mut vec = Vec::with_capacity(self.len());
-        // SAFETY: convert will initialize every value in the vector without reading them,
-        // so this is safe to do instead of double initialize from resize, and we're setting it to
-        // same value as capacity.
-        unsafe { vec.set_len(self.len()) };
+        let mut vec = vec![0f64; self.len()];
         self.convert_to_f64_slice(&mut vec);
         vec
     }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -129,21 +129,13 @@ impl HalfFloatVecExt for Vec<f16> {
     }
 
     fn from_f32_slice(slice: &[f32]) -> Self {
-        let mut vec = Vec::with_capacity(slice.len());
-        // SAFETY: convert will initialize every value in the vector without reading them,
-        // so this is safe to do instead of double initialize from resize, and we're setting it to
-        // same value as capacity.
-        unsafe { vec.set_len(slice.len()) };
+        let mut vec = vec![f16::from_bits(0); slice.len()];
         vec.convert_from_f32_slice(slice);
         vec
     }
 
     fn from_f64_slice(slice: &[f64]) -> Self {
-        let mut vec = Vec::with_capacity(slice.len());
-        // SAFETY: convert will initialize every value in the vector without reading them,
-        // so this is safe to do instead of double initialize from resize, and we're setting it to
-        // same value as capacity.
-        unsafe { vec.set_len(slice.len()) };
+        let mut vec = vec![f16::from_bits(0); slice.len()];
         vec.convert_from_f64_slice(slice);
         vec
     }
@@ -171,21 +163,13 @@ impl HalfFloatVecExt for Vec<bf16> {
     }
 
     fn from_f32_slice(slice: &[f32]) -> Self {
-        let mut vec = Vec::with_capacity(slice.len());
-        // SAFETY: convert will initialize every value in the vector without reading them,
-        // so this is safe to do instead of double initialize from resize, and we're setting it to
-        // same value as capacity.
-        unsafe { vec.set_len(slice.len()) };
+        let mut vec = vec![bf16::from_bits(0); slice.len()];
         vec.convert_from_f32_slice(slice);
         vec
     }
 
     fn from_f64_slice(slice: &[f64]) -> Self {
-        let mut vec = Vec::with_capacity(slice.len());
-        // SAFETY: convert will initialize every value in the vector without reading them,
-        // so this is safe to do instead of double initialize from resize, and we're setting it to
-        // same value as capacity.
-        unsafe { vec.set_len(slice.len()) };
+        let mut vec = vec![bf16::from_bits(0); slice.len()];
         vec.convert_from_f64_slice(slice);
         vec
     }


### PR DESCRIPTION
Minor improvements to safety and soundness:

- set_len [requires the vector to have been previously initialized](https://doc.rust-lang.org/std/vec/struct.Vec.html#safety-2).
- convert.rs soundness: ensure UB is impossible by checking requirement that array length >=4 . Even if the UB is currently unreachable, future wrong usage can trigger UB.