### PR TITLE
Use neon target-feature in aarch64 target

### DIFF
--- a/src/binary16/arch/aarch64.rs
+++ b/src/binary16/arch/aarch64.rs
@@ -7,7 +7,7 @@ use core::{
     ptr,
 };
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn f16_to_f32_fp16(i: u16) -> f32 {
     let result: f32;
@@ -19,7 +19,7 @@ pub(super) unsafe fn f16_to_f32_fp16(i: u16) -> f32 {
     result
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn f16_to_f64_fp16(i: u16) -> f64 {
     let result: f64;
@@ -31,7 +31,7 @@ pub(super) unsafe fn f16_to_f64_fp16(i: u16) -> f64 {
     result
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn f32_to_f16_fp16(f: f32) -> u16 {
     let result: u16;
@@ -43,7 +43,7 @@ pub(super) unsafe fn f32_to_f16_fp16(f: f32) -> u16 {
     result
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn f64_to_f16_fp16(f: f64) -> u16 {
     let result: u16;
@@ -55,7 +55,7 @@ pub(super) unsafe fn f64_to_f16_fp16(f: f64) -> u16 {
     result
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn f16x4_to_f32x4_fp16(v: &[u16; 4]) -> [f32; 4] {
     let mut vec = MaybeUninit::<uint16x4_t>::uninit();
@@ -69,7 +69,7 @@ pub(super) unsafe fn f16x4_to_f32x4_fp16(v: &[u16; 4]) -> [f32; 4] {
     *(&result as *const float32x4_t).cast()
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn f32x4_to_f16x4_fp16(v: &[f32; 4]) -> [u16; 4] {
     let mut vec = MaybeUninit::<float32x4_t>::uninit();
@@ -83,7 +83,7 @@ pub(super) unsafe fn f32x4_to_f16x4_fp16(v: &[f32; 4]) -> [u16; 4] {
     *(&result as *const uint16x4_t).cast()
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn f16x4_to_f64x4_fp16(v: &[u16; 4]) -> [f64; 4] {
     let mut vec = MaybeUninit::<uint16x4_t>::uninit();
@@ -102,7 +102,7 @@ pub(super) unsafe fn f16x4_to_f64x4_fp16(v: &[u16; 4]) -> [f64; 4] {
     *[low, high].as_ptr().cast()
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn f64x4_to_f16x4_fp16(v: &[f64; 4]) -> [u16; 4] {
     let mut low = MaybeUninit::<float64x2_t>::uninit();
@@ -122,7 +122,7 @@ pub(super) unsafe fn f64x4_to_f16x4_fp16(v: &[f64; 4]) -> [u16; 4] {
     *(&result as *const uint16x4_t).cast()
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn add_f16_fp16(a: u16, b: u16) -> u16 {
     let result: u16;
@@ -135,7 +135,7 @@ pub(super) unsafe fn add_f16_fp16(a: u16, b: u16) -> u16 {
     result
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn subtract_f16_fp16(a: u16, b: u16) -> u16 {
     let result: u16;
@@ -148,7 +148,7 @@ pub(super) unsafe fn subtract_f16_fp16(a: u16, b: u16) -> u16 {
     result
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn multiply_f16_fp16(a: u16, b: u16) -> u16 {
     let result: u16;
@@ -161,7 +161,7 @@ pub(super) unsafe fn multiply_f16_fp16(a: u16, b: u16) -> u16 {
     result
 }
 
-#[target_feature(enable = "fp16")]
+#[target_feature(enable = "fp16", enable = "neon")]
 #[inline]
 pub(super) unsafe fn divide_f16_fp16(a: u16, b: u16) -> u16 {
     let result: u16;


### PR DESCRIPTION
This fix is for avoiding the below error in aarch64 target
```
...
error: register class `vreg` requires the `neon` target feature
   --> /home/changho/zpzigi754/half-rs/src/binary16/arch/aarch64.rs:170:9
    |
170 |         out(vreg) result,
    |         ^^^^^^^^^^^^^^^^

error: register class `vreg` requires the `neon` target feature
   --> /home/changho/zpzigi754/half-rs/src/binary16/arch/aarch64.rs:171:9
    |
171 |         in(vreg) a,
    |         ^^^^^^^^^^

error: register class `vreg` requires the `neon` target feature
   --> /home/changho/zpzigi754/half-rs/src/binary16/arch/aarch64.rs:172:9
    |
172 |         in(vreg) b,
    |         ^^^^^^^^^^

error: aborting due to 32 previous errors

error: could not compile `half` (lib) due to 33 previous errors
error: Failed to execute cargo (exit status: 101). Found 33 compilation errors.
```