### PR TITLE
Add Bincode 2.0 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bincode"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +316,7 @@ dependencies = [
 name = "half"
 version = "2.4.1"
 dependencies = [
+ "bincode",
  "bytemuck",
  "cfg-if",
  "criterion",
@@ -782,6 +802,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ std = ["alloc"]
 use-intrinsics = []                         # Deprecated
 alloc = []
 rand_distr = ["dep:rand", "dep:rand_distr"]
+bincode = ["dep:bincode"]
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -35,6 +36,7 @@ zerocopy = { version = "0.6.0", default-features = false, optional = true }
 rand = { version = "0.8.5", default-features = false, optional = true }
 rand_distr = { version = "0.4.3", default-features = false, optional = true }
 rkyv = { version = "0.7", optional = true }
+bincode = { version = "=2.0.0-rc.3", optional = true }
 
 [target.'cfg(target_arch = "spirv")'.dependencies]
 crunchy = "0.2.2"

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -1377,7 +1377,6 @@ impl Encode for f16 {
         &self,
         encoder: &mut E,
     ) -> Result<(), bincode::error::EncodeError> {
-        println!("encoding: {:?}", self.0.to_be_bytes());
         encoder.writer().write(&self.0.to_be_bytes())
     }
 }

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -1337,6 +1337,51 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
     }
 }
 
+#[cfg(feature = "bincode")]
+use bincode::{de::read::Reader, enc::write::Writer, BorrowDecode, Decode, Encode};
+
+#[cfg(feature = "bincode")]
+impl Decode for f16 {
+    fn decode<D: bincode::de::Decoder>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let mut bytes: [u8; size_of::<f16>()] = [0; size_of::<f16>()];
+        decoder.reader().read(&mut bytes)?;
+
+        let b0 = *bytes.get(0).unwrap_or(&0);
+        let b1 = *bytes.get(1).unwrap_or(&0);
+
+        Ok(Self::from_bits(u16::from_be_bytes([b0, b1])))
+    }
+}
+
+#[cfg(feature = "bincode")]
+
+impl<'de> BorrowDecode<'de> for f16 {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let mut bytes: [u8; size_of::<f16>()] = [0; size_of::<f16>()];
+        decoder.reader().read(&mut bytes)?;
+
+        let b0 = *bytes.get(0).unwrap_or(&0);
+        let b1 = *bytes.get(1).unwrap_or(&0);
+
+        Ok(Self::from_bits(u16::from_be_bytes([b0, b1])))
+    }
+}
+
+#[cfg(feature = "bincode")]
+impl Encode for f16 {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        println!("encoding: {:?}", self.0.to_be_bytes());
+        encoder.writer().write(&self.0.to_be_bytes())
+    }
+}
+
 #[allow(
     clippy::cognitive_complexity,
     clippy::float_cmp,


### PR DESCRIPTION
Bincode 2.0 will move away from using Serde's serialize/deserialize into it's own Decode/Encode structs, and this adds a bincode feature flag that supports them.

Some notes:
- Yes it's a release candidate for bincode, it might have to be updated when bincode actually reaches 2.0, but it's been at rc3 since February and idk when they're actually gonna launch 2.0 so I see no problem in doing this now even if they have to change it later.
- I've never contributed and don't know if there's a better place to place this code, so edits are open for maintainers if there's something minor that needs to be edited.