### PR TITLE
feat: adding rkyv export support and convert back to native type

### DIFF
--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -1320,6 +1320,15 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
     }
 }
 
+#[cfg(feature = "rkyv")]
+impl Archivedbf16 {
+    /// Convert an archived `bf16` back to native `bf16`.
+    #[inline]
+    pub fn to_native(&self) -> bf16 {
+        bf16(self.0.to_native())
+    }
+}
+
 #[allow(
     clippy::cognitive_complexity,
     clippy::float_cmp,

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -1337,6 +1337,15 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
     }
 }
 
+#[cfg(feature = "rkyv")]
+impl Archivedf16 {
+    /// Convert an archived f16 back to a native f16
+    #[inline]
+    pub fn to_native(&self) -> f16 {
+        f16(self.0.to_native())
+    }
+}
+
 #[allow(
     clippy::cognitive_complexity,
     clippy::float_cmp,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,12 @@ pub mod slice;
 pub mod vec;
 
 pub use bfloat::bf16;
+#[cfg(feature = "rkyv")]
+pub use bfloat::Archivedbf16;
+
 pub use binary16::f16;
+#[cfg(feature = "rkyv")]
+pub use binary16::Archivedf16;
 
 #[cfg(feature = "rand_distr")]
 mod rand_distr;


### PR DESCRIPTION
# feat: add rkyv export support and convert back to native type

## Summary

Add `rkyv`-gated helpers to convert archived half-precision types back to their native counterparts, and re-export the archived types from the crate root.

## Changes

- `src/bfloat.rs`
  - Under `#[cfg(feature = "rkyv")]`, implement `impl Archivedbf16`:
    - Add `pub fn to_native(&self) -> bf16` to convert the archived value back to `bf16`.

- `src/binary16.rs`
  - Under `#[cfg(feature = "rkyv")]`, implement `impl Archivedf16`:
    - Add `pub fn to_native(&self) -> f16` to convert the archived value back to `f16`.

- `src/lib.rs`
  - Under `#[cfg(feature = "rkyv")]`:
    - Re-export `bfloat::Archivedbf16`.
    - Re-export `binary16::Archivedf16`.

## Motivation

These helpers make it easier to round-trip `bf16`/`f16` when using `rkyv`, and the root re-exports improve ergonomics by exposing the archived types alongside their native counterparts.
