### PR TITLE
Replace float transmutes with to/from_bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["f16", "bfloat16", "no_std"]
 license = "MIT OR Apache-2.0"
 categories = ["no-std", "data-structures", "encoding"]
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.83"
 exclude = [".git*", ".editorconfig", ".circleci", ".mailmap"]
 
 [features]

--- a/src/bfloat/convert.rs
+++ b/src/bfloat/convert.rs
@@ -1,11 +1,8 @@
 use crate::leading_zeros::leading_zeros_u16;
-use zerocopy::transmute;
 
 #[inline]
 pub(crate) const fn f32_to_bf16(value: f32) -> u16 {
-    // TODO: Replace transmute with to_bits() once to_bits is const-stabilized
-    // Convert to raw bytes
-    let x: u32 = transmute!(value);
+    let x: u32 = value.to_bits();
 
     // check for NaN
     if x & 0x7FFF_FFFFu32 > 0x7F80_0000u32 {
@@ -24,10 +21,7 @@ pub(crate) const fn f32_to_bf16(value: f32) -> u16 {
 
 #[inline]
 pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
-    // TODO: Replace transmute with to_bits() once to_bits is const-stabilized
-    // Convert to raw bytes, truncating the last 32-bits of mantissa; that precision will always
-    // be lost on half-precision.
-    let val: u64 = transmute!(value);
+    let val: u64 = value.to_bits();
     let x = (val >> 32) as u32;
 
     // Extract IEEE754 components
@@ -95,18 +89,16 @@ pub(crate) const fn bf16_to_f32(i: u16) -> f32 {
     // TODO: Replace transmute with from_bits() once from_bits is const-stabilized
     // If NaN, keep current mantissa but also set most significiant mantissa bit
     if i & 0x7FFFu16 > 0x7F80u16 {
-        transmute!((i as u32 | 0x0040u32) << 16)
+        f32::from_bits((i as u32 | 0x0040u32) << 16)
     } else {
-        transmute!((i as u32) << 16)
+        f32::from_bits((i as u32) << 16)
     }
 }
 
 #[inline]
 pub(crate) const fn bf16_to_f64(i: u16) -> f64 {
-    // TODO: Replace transmute with from_bits() once from_bits is const-stabilized
-    // Check for signed zero
     if i & 0x7FFFu16 == 0 {
-        return transmute!((i as u64) << 48);
+        return f64::from_bits((i as u64) << 48);
     }
 
     let half_sign = (i & 0x8000u16) as u64;
@@ -117,10 +109,10 @@ pub(crate) const fn bf16_to_f64(i: u16) -> f64 {
     if half_exp == 0x7F80u64 {
         // Check for signed infinity if mantissa is zero
         if half_man == 0 {
-            return transmute!((half_sign << 48) | 0x7FF0_0000_0000_0000u64);
+            return f64::from_bits((half_sign << 48) | 0x7FF0_0000_0000_0000u64);
         } else {
             // NaN, keep current mantissa but also set most significiant mantissa bit
-            return transmute!((half_sign << 48) | 0x7FF8_0000_0000_0000u64 | (half_man << 45));
+            return f64::from_bits((half_sign << 48) | 0x7FF8_0000_0000_0000u64 | (half_man << 45));
         }
     }
 
@@ -137,10 +129,10 @@ pub(crate) const fn bf16_to_f64(i: u16) -> f64 {
         // Rebias and adjust exponent
         let exp = ((1023 - 127 - e) as u64) << 52;
         let man = (half_man << (46 + e)) & 0xF_FFFF_FFFF_FFFFu64;
-        return transmute!(sign | exp | man);
+        return f64::from_bits(sign | exp | man);
     }
     // Rebias exponent for a normalized normal
     let exp = ((unbiased_exp + 1023) as u64) << 52;
     let man = (half_man & 0x007Fu64) << 45;
-    transmute!(sign | exp | man)
+    f64::from_bits(sign | exp | man)
 }

--- a/src/binary16/arch.rs
+++ b/src/binary16/arch.rs
@@ -554,9 +554,7 @@ fn convert_chunked_slice_4<S: Copy + Default, D: Copy>(
 
 #[inline]
 pub(crate) const fn f32_to_f16_fallback(value: f32) -> u16 {
-    // TODO: Replace mem::transmute with to_bits() once to_bits is const-stabilized
-    // Convert to raw bytes
-    let x: u32 = unsafe { mem::transmute::<f32, u32>(value) };
+    let x: u32 = value.to_bits();
 
     // Extract IEEE754 components
     let sign = x & 0x8000_0000u32;
@@ -617,8 +615,7 @@ pub(crate) const fn f32_to_f16_fallback(value: f32) -> u16 {
 pub(crate) const fn f64_to_f16_fallback(value: f64) -> u16 {
     // Convert to raw bytes, truncating the last 32-bits of mantissa; that precision will always
     // be lost on half-precision.
-    // TODO: Replace mem::transmute with to_bits() once to_bits is const-stabilized
-    let val: u64 = unsafe { mem::transmute::<f64, u64>(value) };
+    let val: u64 = value.to_bits();
     let x = (val >> 32) as u32;
 
     // Extract IEEE754 components
@@ -684,9 +681,8 @@ pub(crate) const fn f64_to_f16_fallback(value: f64) -> u16 {
 #[inline]
 pub(crate) const fn f16_to_f32_fallback(i: u16) -> f32 {
     // Check for signed zero
-    // TODO: Replace mem::transmute with from_bits() once from_bits is const-stabilized
     if i & 0x7FFFu16 == 0 {
-        return unsafe { mem::transmute::<u32, f32>((i as u32) << 16) };
+        return f32::from_bits((i as u32) << 16);
     }
 
     let half_sign = (i & 0x8000u16) as u32;
@@ -697,12 +693,10 @@ pub(crate) const fn f16_to_f32_fallback(i: u16) -> f32 {
     if half_exp == 0x7C00u32 {
         // Check for signed infinity if mantissa is zero
         if half_man == 0 {
-            return unsafe { mem::transmute::<u32, f32>((half_sign << 16) | 0x7F80_0000u32) };
+            return f32::from_bits((half_sign << 16) | 0x7F80_0000u32);
         } else {
             // NaN, keep current mantissa but also set most significiant mantissa bit
-            return unsafe {
-                mem::transmute::<u32, f32>((half_sign << 16) | 0x7FC0_0000u32 | (half_man << 13))
-            };
+            return f32::from_bits((half_sign << 16) | 0x7FC0_0000u32 | (half_man << 13));
         }
     }
 
@@ -719,21 +713,20 @@ pub(crate) const fn f16_to_f32_fallback(i: u16) -> f32 {
         // Rebias and adjust exponent
         let exp = (127 - 15 - e) << 23;
         let man = (half_man << (14 + e)) & 0x7F_FF_FFu32;
-        return unsafe { mem::transmute::<u32, f32>(sign | exp | man) };
+        return f32::from_bits(sign | exp | man);
     }
 
     // Rebias exponent for a normalized normal
     let exp = ((unbiased_exp + 127) as u32) << 23;
     let man = (half_man & 0x03FFu32) << 13;
-    unsafe { mem::transmute::<u32, f32>(sign | exp | man) }
+    f32::from_bits(sign | exp | man)
 }
 
 #[inline]
 pub(crate) const fn f16_to_f64_fallback(i: u16) -> f64 {
     // Check for signed zero
-    // TODO: Replace mem::transmute with from_bits() once from_bits is const-stabilized
     if i & 0x7FFFu16 == 0 {
-        return unsafe { mem::transmute::<u64, f64>((i as u64) << 48) };
+        return f64::from_bits((i as u64) << 48);
     }
 
     let half_sign = (i & 0x8000u16) as u64;
@@ -744,16 +737,10 @@ pub(crate) const fn f16_to_f64_fallback(i: u16) -> f64 {
     if half_exp == 0x7C00u64 {
         // Check for signed infinity if mantissa is zero
         if half_man == 0 {
-            return unsafe {
-                mem::transmute::<u64, f64>((half_sign << 48) | 0x7FF0_0000_0000_0000u64)
-            };
+            return f64::from_bits((half_sign << 48) | 0x7FF0_0000_0000_0000u64);
         } else {
             // NaN, keep current mantissa but also set most significiant mantissa bit
-            return unsafe {
-                mem::transmute::<u64, f64>(
-                    (half_sign << 48) | 0x7FF8_0000_0000_0000u64 | (half_man << 42),
-                )
-            };
+            return f64::from_bits((half_sign << 48) | 0x7FF8_0000_0000_0000u64 | (half_man << 42));
         }
     }
 
@@ -770,13 +757,13 @@ pub(crate) const fn f16_to_f64_fallback(i: u16) -> f64 {
         // Rebias and adjust exponent
         let exp = ((1023 - 15 - e) as u64) << 52;
         let man = (half_man << (43 + e)) & 0xF_FFFF_FFFF_FFFFu64;
-        return unsafe { mem::transmute::<u64, f64>(sign | exp | man) };
+        return f64::from_bits(sign | exp | man);
     }
 
     // Rebias exponent for a normalized normal
     let exp = ((unbiased_exp + 1023) as u64) << 52;
     let man = (half_man & 0x03FFu64) << 42;
-    unsafe { mem::transmute::<u64, f64>(sign | exp | man) }
+    f64::from_bits(sign | exp | man)
 }
 
 #[inline]


### PR DESCRIPTION
This requires an MSRV bump to `1.83` so if I understand policy correctly this would go in a `2.8` release. In any case this PR ca be left around and delayed until then. The last change was a good year back; since then Rust marked a whole bunch of intrinsics as `safe` ([1.87](https://releases.rs/docs/1.87.0/#libraries) with further cpu features etc. added up to 1.91). If desirable, a little bit of house keeping to make use of that may motivate a release with a more current rust-version anyways?