### PR TITLE
use trunctuated mantissa for rounding purposes in f64_to_f16.

### DIFF
--- a/src/bfloat/convert.rs
+++ b/src/bfloat/convert.rs
@@ -27,6 +27,7 @@ pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
     // TODO: Replace transmute with to_bits() once to_bits is const-stabilized
     // Convert to raw bytes, truncating the last 32-bits of mantissa; that precision will always
     // be lost on half-precision.
+    // However we use it for rounding purposes.
     let val: u64 = transmute!(value);
     let x = (val >> 32) as u32;
 
@@ -34,6 +35,7 @@ pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
     let sign = x & 0x8000_0000u32;
     let exp = x & 0x7FF0_0000u32;
     let man = x & 0x000F_FFFFu32;
+    let man_low = val as u32;
 
     // Check for all exponent bits being set, which is Infinity or NaN
     if exp == 0x7FF0_0000u32 {
@@ -70,7 +72,7 @@ pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
         let mut half_man = man >> (14 - half_exp);
         // Check for rounding
         let round_bit = 1 << (13 - half_exp);
-        if (man & round_bit) != 0 && (man & (3 * round_bit - 1)) != 0 {
+        if (man & round_bit) != 0 && ((man & (3 * round_bit - 1)) != 0 || man_low != 0) {
             half_man += 1;
         }
         // No exponent for subnormals
@@ -82,7 +84,7 @@ pub(crate) const fn f64_to_bf16(value: f64) -> u16 {
     let half_man = man >> 13;
     // Check for rounding
     let round_bit = 0x0000_1000u32;
-    if (man & round_bit) != 0 && (man & (3 * round_bit - 1)) != 0 {
+    if (man & round_bit) != 0 && ((man & (3 * round_bit - 1)) != 0 || man_low != 0) {
         // Round it
         ((half_sign | half_exp | half_man) + 1) as u16
     } else {

--- a/src/binary16/arch.rs
+++ b/src/binary16/arch.rs
@@ -617,6 +617,7 @@ pub(crate) const fn f32_to_f16_fallback(value: f32) -> u16 {
 pub(crate) const fn f64_to_f16_fallback(value: f64) -> u16 {
     // Convert to raw bytes, truncating the last 32-bits of mantissa; that precision will always
     // be lost on half-precision.
+    // However we use it for rounding purposes.
     // TODO: Replace mem::transmute with to_bits() once to_bits is const-stabilized
     let val: u64 = unsafe { mem::transmute::<f64, u64>(value) };
     let x = (val >> 32) as u32;
@@ -625,6 +626,7 @@ pub(crate) const fn f64_to_f16_fallback(value: f64) -> u16 {
     let sign = x & 0x8000_0000u32;
     let exp = x & 0x7FF0_0000u32;
     let man = x & 0x000F_FFFFu32;
+    let man_low = val as u32;
 
     // Check for all exponent bits being set, which is Infinity or NaN
     if exp == 0x7FF0_0000u32 {
@@ -661,7 +663,7 @@ pub(crate) const fn f64_to_f16_fallback(value: f64) -> u16 {
         let mut half_man = man >> (11 - half_exp);
         // Check for rounding (see comment above functions)
         let round_bit = 1 << (10 - half_exp);
-        if (man & round_bit) != 0 && (man & (3 * round_bit - 1)) != 0 {
+        if (man & round_bit) != 0 && ((man & (3 * round_bit - 1)) != 0 || man_low != 0) {
             half_man += 1;
         }
         // No exponent for subnormals
@@ -673,7 +675,7 @@ pub(crate) const fn f64_to_f16_fallback(value: f64) -> u16 {
     let half_man = man >> 10;
     // Check for rounding (see comment above functions)
     let round_bit = 0x0000_0200u32;
-    if (man & round_bit) != 0 && (man & (3 * round_bit - 1)) != 0 {
+    if (man & round_bit) != 0 && ((man & (3 * round_bit - 1)) != 0  || man_low != 0) {
         // Round it
         ((half_sign | half_exp | half_man) + 1) as u16
     } else {


### PR DESCRIPTION
In f16::from_f64_const() the assertion that the last 32 bits of the mantissa won't affect the outcome of the f16 at all is false for edge cases (rounding).

For example `2.980232238769532e-8f64` is 0x3E60000000000001 as hex. The last 1 should cause number to be rounded up. However before this patch it was just ignored.

I added and additional check for the lower mantissa which will cause the value to be rounded up. 

The full test suite passes however I'm still not fully sure if this is actually correct as it will probably cause most values to be rounded up.

This failure is taken from JavaScript's `Math.f16round` where with this library the test doesn't pass on x86 machines but on arm machines. It also doesn't work with the const version.

The test failure: https://yavashark.dev/test262/#/v/built-ins/Math/f16round/value-conversion.js

The test values used in the test: https://github.com/tc39/test262/blob/ff0d1611d3d5084dabf7b6887c45a7321ec1b531/harness/byteConversionValues.js#L527


The x86 failure is a whole different error which can't be fixed from this libraries side.

