### PR TITLE
impl bytemuck::Pod and Zeroable for Archivedf16 and Archivedbf16

### DIFF
--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -39,11 +39,18 @@ pub(crate) mod convert;
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-#[cfg_attr(feature = "rkyv", rkyv(resolver = Bf16Resolver))]
+#[cfg_attr(feature = "rkyv", rkyv(resolver = Bf16Resolver, derive(Copy, Clone)))]
 #[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
 #[cfg_attr(kani, derive(kani::Arbitrary))]
 #[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
 pub struct bf16(u16);
+
+// SAFETY: `Archivedbf16` is `#[repr(C)](rkyv::rend::u16_le)` — 2 bytes,
+// every bit pattern valid, no padding, no `UnsafeCell`.
+#[cfg(all(feature = "rkyv", feature = "bytemuck"))]
+unsafe impl Zeroable for Archivedbf16 {}
+#[cfg(all(feature = "rkyv", feature = "bytemuck"))]
+unsafe impl Pod for Archivedbf16 {}
 
 impl bf16 {
     /// Constructs a [`struct@bf16`] value from the raw bits.

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -38,12 +38,19 @@ pub(crate) mod arch;
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-#[cfg_attr(feature = "rkyv", rkyv(resolver = F16Resolver))]
+#[cfg_attr(feature = "rkyv", rkyv(resolver = F16Resolver, derive(Copy, Clone)))]
 #[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
 #[cfg_attr(kani, derive(kani::Arbitrary))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]
 pub struct f16(u16);
+
+// SAFETY: `Archivedf16` is `#[repr(C)](rkyv::rend::u16_le)` — 2 bytes,
+// every bit pattern valid, no padding, no `UnsafeCell`.
+#[cfg(all(feature = "rkyv", feature = "bytemuck"))]
+unsafe impl Zeroable for Archivedf16 {}
+#[cfg(all(feature = "rkyv", feature = "bytemuck"))]
+unsafe impl Pod for Archivedf16 {}
 
 impl f16 {
     /// Constructs a 16-bit floating point value from the raw bits.


### PR DESCRIPTION
Lets users with both `rkyv` and `bytemuck` features use `bytemuck::cast_slice` between the rkyv archive form and native. Pod requires Copy, so also adds `#[rkyv(derive(Copy, Clone))]` on the source structs.
