### PR TITLE
Derive zerocopy traits on Archivedf16 and Archivedbf16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "quickcheck_macros",
  "rand 0.9.0",
  "rand_distr",
+ "rend",
  "rkyv",
  "serde",
  "zerocopy",
@@ -665,6 +666,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 dependencies = [
  "bytecheck",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ alloc = []
 rand_distr = ["dep:rand", "dep:rand_distr"]
 zerocopy = []                               # Deprecated
 nightly = []
+rkyv = ["dep:rkyv", "dep:rend"]
 
 [dependencies]
 cfg-if = "1.0.0"
@@ -42,6 +43,9 @@ rand = { version = "0.9.0", default-features = false, features = [
 ], optional = true }
 rand_distr = { version = "0.5.0", default-features = false, optional = true }
 rkyv = { version = "0.8.0", optional = true }
+rend = { version = "0.5", default-features = false, features = [
+    "zerocopy-0_8",
+], optional = true }
 arbitrary = { version = "1.4.1", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "spirv")'.dependencies]

--- a/src/bfloat.rs
+++ b/src/bfloat.rs
@@ -39,7 +39,14 @@ pub(crate) mod convert;
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-#[cfg_attr(feature = "rkyv", rkyv(resolver = Bf16Resolver))]
+#[cfg_attr(
+    feature = "rkyv",
+    rkyv(
+        resolver = Bf16Resolver,
+        derive(zerocopy::FromBytes, zerocopy::IntoBytes,
+               zerocopy::Immutable, zerocopy::KnownLayout),
+    )
+)]
 #[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
 #[cfg_attr(kani, derive(kani::Arbitrary))]
 #[derive(FromBytes, Immutable, IntoBytes, KnownLayout)]

--- a/src/binary16.rs
+++ b/src/binary16.rs
@@ -38,7 +38,14 @@ pub(crate) mod arch;
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-#[cfg_attr(feature = "rkyv", rkyv(resolver = F16Resolver))]
+#[cfg_attr(
+    feature = "rkyv",
+    rkyv(
+        resolver = F16Resolver,
+        derive(zerocopy::FromBytes, zerocopy::IntoBytes,
+               zerocopy::Immutable, zerocopy::KnownLayout),
+    )
+)]
 #[cfg_attr(feature = "bytemuck", derive(Zeroable, Pod))]
 #[cfg_attr(kani, derive(kani::Arbitrary))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]


### PR DESCRIPTION
Derives `zerocopy::FromBytes` / `IntoBytes` / `Immutable` / `KnownLayout` on `Archivedf16` / `Archivedbf16` when the `rkyv` feature is enabled, so the archived types work with zerocopy's safe APIs (e.g. `zerocopy::Ref::from_bytes`).
